### PR TITLE
[FE]いいね機能といいねした募集を一覧表示するページの実装

### DIFF
--- a/src/components/atoms/LikeButton.tsx
+++ b/src/components/atoms/LikeButton.tsx
@@ -1,0 +1,28 @@
+
+import { userToRecruitLikeRepository } from "@/modules/user-recruit-like/userToRecruitLikeRepository";
+import { useRouter } from "next/router";
+
+type LikeButtonProps = {
+  recruitId: string
+  isLiked: boolean
+}
+
+export const LikeButton = ({ recruitId, isLiked }: LikeButtonProps) => {
+  const router = useRouter()
+  const handleLike = async() => {
+    if (!isLiked) {
+      await userToRecruitLikeRepository.addLike(recruitId)
+    } else {
+      await userToRecruitLikeRepository.deleteLike(recruitId)
+    }
+    router.reload()
+  }
+
+  return (
+    <div>
+      <button onClick={handleLike}>
+        { isLiked ? 'いいね済み' : 'いいねする' }
+      </button>
+    </div>
+  )
+}

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -13,8 +13,9 @@ export const Header = (): JSX.Element => {
     {href: '/profiles/editProfile', label: 'マイページへ'},
     {href: `/profiles/${userStateVal?.id}/myRecruitsAndRelatedRecruits`, label: '募集一覧'},
     {href: '/product/myProductsAndRelatedProducts', label: '成果物一覧'},
-    {href: '/', label: 'お問合せ'},
-    {href: '/', label: 'ログアウト'},
+    {href: '/recruit/likedRecruitList', label: 'いいねした募集'},
+    // {href: '/', label: 'お問合せ'},
+    // {href: '/', label: 'ログアウト'},
   ]
 
   return (

--- a/src/components/organisms/RecruitCard.tsx
+++ b/src/components/organisms/RecruitCard.tsx
@@ -52,7 +52,7 @@ export const RecruitCard = ({
         </div>
         <div className="w-1/3 flex flex-col justify-center items-center">
         <Link href={`recruit/${id}/recruitDetail`}
-          className=" text-green-800  rounded-lg focus:outline-none focus:border-transparent text-center bg-transparent text-sm sm:text-lg hover:bg-pink-300 hover:text-white p-3"
+          className=" text-green-800  rounded-lg focus:outline-none focus:border-transparent text-center bg-transparent text-sm sm:text-lg hover:bg-pink-200 hover:text-white p-3"
         >
           詳細を見る
         </Link>

--- a/src/components/organisms/RecruitList.tsx
+++ b/src/components/organisms/RecruitList.tsx
@@ -25,14 +25,12 @@ export const RecruitList = (): JSX.Element => {
   };
 
   return (
-    <div className="bg-gray-100 pt-10 ">
+    <div className="bg-gray-100 pt-10 h-screen">
       <div className="grid mx-12 sm:mx-20 gap-x-20 gap-y-8 sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2">
           {filteredRecruits.length == 0 && <p>条件に一致する募集はありません</p>}
           { filteredRecruits?.map((recruit: RecruitCardProps) => {
-            if (user?.id !== recruit?.recruiter?.id)
+            if (user?.id !== recruit?.recruiter?.id) {
               return (
-                //useridができたら自分の投稿が表示されないようにする
-                //現状はuserIDがなかったので記述を消してます
                 <RecruitCard
                   key={recruit.id}
                   id={recruit.id}
@@ -42,14 +40,13 @@ export const RecruitList = (): JSX.Element => {
                   hackthonName={recruit.hackthonName}
                 />
               );
+            }
           })}
       </div>
 
-      <div className="fixed bottom-0 right-0 mr-10 mb-10 bg-green-400 h-14 w-14 sm:w-20 sm:h-20 rounded-full flex col items-center justify-center">
-        <Link href={"/addRecruit"} className="text-white text-4xl font-bold">
-          +
-        </Link>
-      </div>
+      <Link href={"/addRecruit"} className="text-white text-4xl font-bold fixed bottom-0 right-0 mr-10 mb-10 bg-green-400 h-14 w-14 sm:w-20 sm:h-20 rounded-full flex col items-center justify-center">
+        +
+      </Link>
     </div>
   );
 

--- a/src/components/templetes/user/AddRecruit.tsx
+++ b/src/components/templetes/user/AddRecruit.tsx
@@ -16,7 +16,7 @@ export type FormRecruitData = {
   details: string;
   programingSkills: ProgramingSkill[];
   developmentPeriod: string;
-  hackthonUrl: String;
+  hackathonUrl: String;
   numberOfApplicants: number; //募集人数
 };
 
@@ -43,13 +43,15 @@ export const AddRecruit = () => {
     if (!userState) return;
     let userId = JSON.parse(userState)["UserState"].uid;
 
+    console.log
+
     const recruitData: FormRecruitData = {
       hackthonName: data.hackthonName,
       headline: data.headline,
       details: data.details,
       programingSkills: data.programingSkills,
       developmentPeriod: data.developmentPeriod,
-      hackthonUrl: data.hackthonUrl,
+      hackathonUrl: data.hackathonUrl,
       numberOfApplicants: data.numberOfApplicants,
     };
 

--- a/src/components/templetes/user/LikedRecruitList.tsx
+++ b/src/components/templetes/user/LikedRecruitList.tsx
@@ -1,0 +1,37 @@
+import { RecruitCard } from "@/components/organisms/RecruitCard"
+import { UserState } from "@/global-states/atoms"
+import { recruitRepository } from "@/modules/recruit/recruit.repository"
+import { Recruit } from "@/types/recruit"
+import { useEffect, useState } from "react"
+
+export const LikedRecruitList = () => {
+  const [ likedRecruits, setLikedRecruits ] = useState<Recruit[]>([])
+
+  useEffect(() => {
+    (async () => {
+      const fetchedLikedRecruits = await recruitRepository.getLikedRecruits()
+      setLikedRecruits(fetchedLikedRecruits)
+    })()
+  }, [])
+
+  return (
+    <div className="bg-gray-100 pt-10 h-screen">
+      <div className="text-center mb-10  mx-12 sm:mx-20 p-5 font-bold bg-green-300 text-white rounded-sm inline-block">いいねした募集一覧</div>
+      <div className="grid mx-12 sm:mx-20 gap-x-20 gap-y-8 sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2">
+          {likedRecruits.length == 0 && <p>条件に一致する募集はありません</p>}
+          { likedRecruits?.map((recruit: Recruit) => {
+              return (
+                <RecruitCard
+                  key={recruit.id}
+                  id={recruit.id}
+                  createdAt={recruit.createdAt}
+                  headline={recruit.headline}
+                  programingSkills={recruit.programingSkills}
+                  hackthonName={recruit.hackthonName}
+                />
+              );
+          })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/templetes/user/RecruitDetail.tsx
+++ b/src/components/templetes/user/RecruitDetail.tsx
@@ -1,3 +1,4 @@
+import { LikeButton } from "@/components/atoms/LikeButton";
 import { SuccessOrFailureModal } from "@/components/organisms/SuccessOrFailureModal";
 import { UserState } from "@/global-states/atoms";
 import { recruitRepository } from "@/modules/recruit/recruit.repository";
@@ -19,7 +20,6 @@ export const RecruitDetail: React.FC = () => {
   const { id } = router.query;
   const [ recruit, setRecruit ] = useState<Recruit>();
 
-
   useEffect(() => {
     (async () => {
       const fetchedRecruit = await recruitRepository.getRecruitById(id as string)
@@ -32,6 +32,8 @@ export const RecruitDetail: React.FC = () => {
   const [color, setColor] = useState<boolean>();
   const closeModal = () => setIsOpen(false);
   const isParticipant = recruit?.userRecruitParticipant?.some(participant => participant.userId == user?.id);
+  //いいねをしているかしていないかの判定に利用する
+  const isLiked = recruit?.userToRecruitLikes?.some((like) => like.userId === user?.id);
 
   const applyForJoin = async() => {
     await userRecruitParticipantRepository.applyForJoin(recruit?.id as string);
@@ -121,6 +123,10 @@ export const RecruitDetail: React.FC = () => {
             <div className="ml-5">
               {recruit && format(new Date(recruit?.createdAt), 'yyyy-MM-dd')}
             </div>
+            <LikeButton 
+              recruitId={recruit?.id as string} 
+              isLiked={isLiked!} 
+            />
             <div className="w-1/2 flex justify-end mr-5">
               <Link href={"/"} className="bg-green-400 px-12 py-2 rounded-md text-white">戻る</Link>
             </div>

--- a/src/modules/recruit/recruit.repository.ts
+++ b/src/modules/recruit/recruit.repository.ts
@@ -2,7 +2,6 @@ import { FormRecruitData } from "@/components/templetes/user/AddRecruit";
 import { Recruit } from "@/types/recruit";
 import { axiosInstance } from "@/libs/axios";
 import { ConfirmModal } from "@/types/confirmModal";
-import axios from "axios";
 
 export const recruitRepository = {
   //募集の一覧取得
@@ -41,6 +40,15 @@ export const recruitRepository = {
     })).data
 
     return relatedRecruits
+  },
+
+  //いいねしたRecruitを全件取得
+  async getLikedRecruits(): Promise<Recruit[]> {
+    const likedRecruits = ( await axiosInstance.get('/user-recruit/liked-recruits').catch((error) => {
+      throw new Error('取得に失敗しました。')
+    })).data
+
+    return likedRecruits
   },
 
   //募集の作成

--- a/src/modules/user-recruit-like/userToRecruitLikeRepository.tsx
+++ b/src/modules/user-recruit-like/userToRecruitLikeRepository.tsx
@@ -1,0 +1,21 @@
+import { axiosInstance } from "@/libs/axios";
+
+export const userToRecruitLikeRepository = {
+  //いいねする
+  async addLike(recruitId: string) {
+    try {
+      await axiosInstance.post('/user-to-recruit-like', { recruitId })
+    } catch (error) {
+      throw new Error(`いいねすることに失敗しました。 ${error}`)
+    }
+  },
+
+  //いいね削除する
+  async deleteLike(id: string) {
+    try {
+      await axiosInstance.delete(`/user-to-recruit-like/${id}`)
+    } catch (error) {
+      throw new Error('いいねの削除に失敗しました。')
+    }
+  }
+};

--- a/src/pages/recruit/likedRecruitList.tsx
+++ b/src/pages/recruit/likedRecruitList.tsx
@@ -1,0 +1,13 @@
+import { UserLayout } from "@/components/templetes/layouts/UserLayout"
+import { LikedRecruitList } from "@/components/templetes/user/LikedRecruitList";
+import { ReactElement } from "react"
+
+const LikedRecruitListPage = () => (
+  <><LikedRecruitList /></>
+)
+
+LikedRecruitListPage.getLayout = (page: ReactElement) => (
+  <UserLayout>{page}</UserLayout>
+);
+
+export default LikedRecruitListPage

--- a/src/types/recruit.ts
+++ b/src/types/recruit.ts
@@ -2,6 +2,7 @@ import { UserRecruitParticipant } from "./UserRecruitParticipant";
 import { Product } from "./product";
 import { ProgramingSkill } from "./programingSkill";
 import { User } from "./user";
+import { UserToRecruitLike } from "./userToRecruitLike";
 
 export type Recruit = {
   id: string;
@@ -18,6 +19,7 @@ export type Recruit = {
   applications?: User[]
   userRecruitParticipant?: UserRecruitParticipant[];
   product: Product[] //BEで配列になっているため1対1の関係だが配列で受け取る必要がある
+  userToRecruitLikes?: UserToRecruitLike[]
 }
 
 //リファクタ

--- a/src/types/userToRecruitLike.ts
+++ b/src/types/userToRecruitLike.ts
@@ -1,0 +1,5 @@
+export type UserToRecruitLike = {
+  id: string
+  userId: string,
+  recruitId: string
+}


### PR DESCRIPTION
--概要
userが募集に対していいねすることができる機能を実装しました。
いいねした募集は`http://localhost:3000/recruit/likedRecruitList`に管理されるようになっています。

--やっていない事
いいねするハートを決め切ることができなかったので次のレスポンシブ対応デザイン変更のタスクでUI自体は整えます。

--BEのコード
https://github.com/ponsAoki/unite-api/pull/13

--動作確認動画
*いいねする
[画面収録 2023-06-30 0.24.28.mov.zip](https://github.com/nagayamajun/unite-replace-front/files/11907625/2023-06-30.0.24.28.mov.zip)
*いいね解除
[画面収録 2023-06-30 0.20.44.mov.zip](https://github.com/nagayamajun/unite-replace-front/files/11907596/2023-06-30.0.20.44.mov.zip)


