### PR TITLE
homeScreenにおける募集一覧のレンダリング方法の変更

### DIFF
--- a/src/pages/homeScreen.tsx
+++ b/src/pages/homeScreen.tsx
@@ -15,6 +15,7 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       recruitsArray,
     },
+    revalidate: 60
   };
 };
 


### PR DESCRIPTION
--概要
homeScreenにおける募集一覧のレンダリング方法をSSG -> ISR に変更しました。

--変更理由
SSGではbuild時のみの変更で募集が反映されないから。
しかし、CSRで取得するにはレンダリング回数が増えてしまうのではないかと考えたのとアプリの特性上常に最新を求めていると感じなかったのでISRを利用。

しかし、アプリ全体で言えることだがしっかりとしたレンダリング理由が存在しない為検討する必要あり。

--確認方法
`npm run build`でISRが走っているか確認