### PR TITLE
アイコンをreact-iconsに総入れ替え

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.7.13",
-        "@heroicons/react": "^2.0.17",
         "@hookform/error-message": "^2.0.1",
         "@tailwindcss/line-clamp": "^0.4.2",
         "@types/node": "18.14.6",
@@ -893,14 +892,6 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.17.tgz",
-      "integrity": "sha512-90GMZktkA53YbNzHp6asVEDevUQCMtxWH+2UK2S8OpnLEu7qckTJPhNxNQG52xIR1WFTwFqtH6bt7a60ZNcLLA==",
-      "peerDependencies": {
-        "react": ">= 16"
       }
     },
     "node_modules/@hookform/error-message": {
@@ -6219,12 +6210,6 @@
       "requires": {
         "client-only": "^0.0.1"
       }
-    },
-    "@heroicons/react": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.17.tgz",
-      "integrity": "sha512-90GMZktkA53YbNzHp6asVEDevUQCMtxWH+2UK2S8OpnLEu7qckTJPhNxNQG52xIR1WFTwFqtH6bt7a60ZNcLLA==",
-      "requires": {}
     },
     "@hookform/error-message": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.13",
-    "@heroicons/react": "^2.0.17",
     "@hookform/error-message": "^2.0.1",
     "@tailwindcss/line-clamp": "^0.4.2",
     "@types/node": "18.14.6",

--- a/src/components/atoms/FormField.tsx
+++ b/src/components/atoms/FormField.tsx
@@ -1,11 +1,11 @@
-import Image from "next/image";
 import { MouseEventHandler, ReactElement } from "react";
+import { AiFillEdit } from "react-icons/ai";
 
 type FormFieldProps = {
   labelText?: string;
   children: ReactElement;
   editable: boolean;
-  onCLick: MouseEventHandler<HTMLImageElement>;
+  onCLick: MouseEventHandler<HTMLButtonElement>;
 };
 
 export const FormField = ({
@@ -18,14 +18,13 @@ export const FormField = ({
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <p>{labelText}</p>
-        <Image
-          src="/pen.gif"
-          alt="鉛筆のロゴ"
-          width={60}
-          height={60}
+        <button
+          type="button"
           onClick={onCLick}
           className={editable ? "" : "hidden"}
-        />
+        >
+          <AiFillEdit className="text-xl" />
+        </button>
       </div>
       {children}
     </div>

--- a/src/components/atoms/PersonIcon.tsx
+++ b/src/components/atoms/PersonIcon.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import { MouseEventHandler, ReactElement } from "react";
+import { BsFillPersonFill } from "react-icons/bs";
+
+type PersonIconProps = {
+  originalIconImageSrc?: string;
+  originalIconImageAlt?: string;
+  defaultIconSize?: number;
+  defaultIconFill?: string;
+  defaultIconClassName?: string;
+  originalIconClassName?: string;
+  onClick?: MouseEventHandler<Element>;
+};
+
+export const PersonIcon = ({
+  originalIconImageSrc,
+  originalIconImageAlt = "人物アイコン",
+  defaultIconSize = 36,
+  defaultIconFill = "gray",
+  defaultIconClassName = "rounded-full bg-white border border-black p-1 color-black-100",
+  originalIconClassName = "rounded-full border border-black",
+  onClick,
+}: PersonIconProps): JSX.Element => (
+  <>
+    {originalIconImageSrc ? (
+      <Image
+        src={originalIconImageSrc}
+        alt={originalIconImageAlt}
+        width={40}
+        height={40}
+        className={originalIconClassName}
+        onClick={onClick}
+      />
+    ) : (
+      <BsFillPersonFill
+        size={defaultIconSize}
+        fill={defaultIconFill}
+        className={defaultIconClassName}
+        onClick={onClick}
+      />
+    )}
+  </>
+);

--- a/src/components/organisms/ChatRoomListMenu.tsx
+++ b/src/components/organisms/ChatRoomListMenu.tsx
@@ -1,9 +1,9 @@
 import { useChatRoomList } from "@/hooks/useChatRoomList";
 import { ChatRoom } from "@/types/chatRoom";
 import { Menu, Transition } from "@headlessui/react";
-import Image from "next/image";
 import Link from "next/link";
 import { Fragment, ReactElement } from "react";
+import { PersonIcon } from "../atoms/PersonIcon";
 
 type Props = {
   children: ReactElement;
@@ -24,7 +24,7 @@ export const ChatRoomListMenu = ({ children }: Props) => {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute z-10 right-2 mt-2 sm:right-0 sm:left-11 w-80 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items className="absolute z-10 right-1 mt-2 sm:right-0 sm:left-11 w-56 sm:w-80 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           {roomList?.map((room: ChatRoom) => (
             <Menu.Item key={room.id} as={Fragment}>
               {({ active }) => (
@@ -34,12 +34,9 @@ export const ChatRoomListMenu = ({ children }: Props) => {
                     active && "bg-[#0000001a]"
                   }`}
                 >
-                  <Image
-                    src={room.interlocutorImageUrl ?? "/avatar.gif"}
-                    alt="対話相手のロゴ"
-                    width={40}
-                    height={40}
-                    className="rounded-full border border-black"
+                  <PersonIcon
+                    originalIconImageSrc={room.interlocutorImageUrl}
+                    originalIconImageAlt={`${room.interlocutorName}のアイコン`}
                   />
                   <div>
                     <p className="min-h-[19px] text-[16px] font-black text-black leading-[19px]">

--- a/src/components/organisms/CorporateHeaderLine.tsx
+++ b/src/components/organisms/CorporateHeaderLine.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
+import { PersonIcon } from "../atoms/PersonIcon";
+import { PiChatCircleDotsThin } from "react-icons/pi";
 
 export const CorporateHeaderLine = (): JSX.Element => {
   const router = useRouter();
@@ -25,10 +27,10 @@ export const CorporateHeaderLine = (): JSX.Element => {
           </Link>
           <div className="flex mr-[4%]">
             <Link href={`/corporation/chat/${arbitraryRoomId}`}>
-              <Image src="/chat.gif" alt="Logo" width={90} height={90} />
+              <PiChatCircleDotsThin size={36} />
             </Link>
             <Link href="#">
-              <Image src="/avatar.gif" alt="Logo" width={90} height={90} />
+              <PersonIcon />
             </Link>
           </div>
         </div>

--- a/src/components/organisms/MobileHeader.tsx
+++ b/src/components/organisms/MobileHeader.tsx
@@ -1,12 +1,13 @@
 import { UserState } from "@/global-states/atoms";
 import { Menu, Transition } from "@headlessui/react";
-import Image from "next/image";
 import Link from "next/link";
 import { Fragment } from "react";
 import { useRecoilValue } from "recoil";
 import { ChatRoomListMenu } from "./ChatRoomListMenu";
+import { PiChatCircleDotsThin } from "react-icons/pi";
+import { PersonIcon } from "../atoms/PersonIcon";
 
-export const Header = (): JSX.Element => {
+export const MobileHeader = (): JSX.Element => {
   const userStateVal = useRecoilValue(UserState);
   const menuLinks = [
     { href: `/profiles/user/${userStateVal?.id}`, label: "マイページへ" },
@@ -30,10 +31,10 @@ export const Header = (): JSX.Element => {
             </p>
           </Link>
         </div>
-        <div className="flex col">
+        <div className="flex">
           <ChatRoomListMenu>
-            <div className="flex justify-center items-center mr-2">
-              <Image src="/chat.gif" alt="Logo" width={40} height={40} />
+            <div className="flex justify-center items-center p-2">
+              <PiChatCircleDotsThin size={36} />
             </div>
           </ChatRoomListMenu>
           <div className="flex items-center">
@@ -45,12 +46,10 @@ export const Header = (): JSX.Element => {
             </p>
             <Menu>
               <Menu.Button>
-                <Image
-                  src={userStateVal?.imageUrl ?? "/avatar.gif"}
-                  alt="Logo"
-                  width={50}
-                  height={50}
-                  className="border rounded-full"
+                <PersonIcon
+                  originalIconImageSrc={userStateVal?.imageUrl}
+                  originalIconImageAlt={`${userStateVal?.name}のアイコン`}
+                  originalIconClassName="rounded-full border border-black w-40 h-40"
                 />
               </Menu.Button>
               <Transition
@@ -62,7 +61,7 @@ export const Header = (): JSX.Element => {
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute right-3 mt-14 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                <Menu.Items className="absolute z-20 right-3 mt-14 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
                   {menuLinks.map((link) => (
                     <Menu.Item key={link.href} as={Fragment}>
                       {({ active }) => (

--- a/src/components/organisms/ProductCard.tsx
+++ b/src/components/organisms/ProductCard.tsx
@@ -1,6 +1,9 @@
 import { FieldValue } from "firebase/firestore";
 import Image from "next/image";
 import Link from "next/link";
+import { PersonIcon } from "../atoms/PersonIcon";
+import { useRecoilValue } from "recoil";
+import { UserState, UserStateType } from "@/global-states/atoms";
 
 type Props = {
   genre: string;
@@ -16,12 +19,16 @@ export const ProductCard = ({
   user_id,
   createDate,
 }: Props) => {
+  const myself = useRecoilValue<UserStateType>(UserState);
 
   return (
     <>
       <div className="group group relative mb-2 h-full w-100 border overflow-hidden rounded-3xl bg-white lg:mb-3 font-caveat">
         <div className="flex justify-center">
-          <Image src="/avatar.gif" width={50} height={50} alt="avatar" />
+          <PersonIcon
+            originalIconImageSrc={myself?.imageUrl}
+            originalIconImageAlt={`${myself?.name}のアイコン`}
+          />
         </div>
         <div className="flex flex-col justify-center ">
           <p className="m-auto p-1">{genre ? `種類: ${genre}` : "No Genre"}</p>

--- a/src/components/organisms/SIdebar.tsx
+++ b/src/components/organisms/SIdebar.tsx
@@ -1,56 +1,74 @@
 import { UserState } from "@/global-states/atoms";
-import Link from "next/link"
+import Link from "next/link";
 import { useRecoilValue } from "recoil";
-import { CiViewList } from 'react-icons/ci'
-import { IoIosCreate } from 'react-icons/io'
-import { AiOutlineHeart } from 'react-icons/ai'
-import { MdOutlineManageAccounts } from 'react-icons/md'
+import { CiViewList } from "react-icons/ci";
+import { IoIosCreate } from "react-icons/io";
+import { AiOutlineHeart } from "react-icons/ai";
+import { MdOutlineManageAccounts } from "react-icons/md";
 import { ChatRoomListMenu } from "./ChatRoomListMenu";
 import Image from "next/image";
-
+import { PiChatCircleDotsThin } from "react-icons/pi";
 
 export const SideBar = (): JSX.Element => {
   const userStateVal = useRecoilValue(UserState);
 
   const menuLinks = [
-    {href: `/homeScreen`, label: '募集一覧', icon: <CiViewList />},
-    {href: `/addRecruit`, label: '募集を作成', icon: <IoIosCreate />},
-    { href: `/profiles/user/${userStateVal?.id}`, label: "マイページへ", icon: <MdOutlineManageAccounts /> },
-    {href: `/profiles/${userStateVal?.id}/myRecruitsAndRelatedRecruits`, label: '参加した/作成した募集', icon: <CiViewList />},
-    {href: '/recruit/likedRecruitList', label: 'いいねした募集', icon: <AiOutlineHeart />},
-    {href: '/product/myProductsAndRelatedProducts', label: '成果物一覧', icon: <CiViewList />},
+    { href: `/homeScreen`, label: "募集一覧", icon: <CiViewList /> },
+    { href: `/addRecruit`, label: "募集を作成", icon: <IoIosCreate /> },
+    {
+      href: `/profiles/user/${userStateVal?.id}`,
+      label: "マイページへ",
+      icon: <MdOutlineManageAccounts />,
+    },
+    {
+      href: `/profiles/${userStateVal?.id}/myRecruitsAndRelatedRecruits`,
+      label: "参加した/作成した募集",
+      icon: <CiViewList />,
+    },
+    {
+      href: "/recruit/likedRecruitList",
+      label: "いいねした募集",
+      icon: <AiOutlineHeart />,
+    },
+    {
+      href: "/product/myProductsAndRelatedProducts",
+      label: "成果物一覧",
+      icon: <CiViewList />,
+    },
     // {href: '/', label: 'お問合せ'},
     // {href: '/', label: 'ログアウト'},
-  ]
+  ];
 
   return (
     <div className="flex flex-col h-auto sm:w-52 md:w-64  bg-gray-800 text-white ">
       <div className="flex justify-center items-center h-20 border-b border-white mx-2">
         <Link href={"/homeScreen"}>
-        <p className="text-xl sm:text-2xl font-bold">
-              <span className="text-green-700">U </span>N 
-              <span className="text-pink-400"> I </span>T E
-            </p>
+          <p className="text-xl sm:text-2xl font-bold">
+            <span className="text-green-700">U </span>N
+            <span className="text-pink-400"> I </span>T E
+          </p>
         </Link>
       </div>
       <div className="flex flex-row items-center justify-start font-semibold h-16 ml-1 w-full hover:bg-green-500">
         <ChatRoomListMenu>
-          <div className="flex justify-start items-center  font-semibold">
-            <Image src="/chat.gif" alt="Logo" width={40} height={40} />
+          <div className="flex justify-start items-center gap-2 font-semibold">
+            <PiChatCircleDotsThin size={24} />
             <p>チャットページ</p>
           </div>
         </ChatRoomListMenu>
       </div>
       <div className="flex flex-col items-center">
-        { menuLinks.map((e, index) => (
-          <Link key={index} href={e.href} className="flex flex-row items-center justify-start font-semibold h-16 ml-2 w-full hover:bg-green-500">
+        {menuLinks.map((e, index) => (
+          <Link
+            key={index}
+            href={e.href}
+            className="flex flex-row items-center justify-start font-semibold h-16 ml-2 w-full hover:bg-green-500"
+          >
             <div className="text-2xl mr-2">{e.icon}</div>
             <div>{e.label}</div>
           </Link>
         ))}
       </div>
-
-
     </div>
-  )
-}
+  );
+};

--- a/src/components/organisms/UserCard.tsx
+++ b/src/components/organisms/UserCard.tsx
@@ -1,5 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
+import { PersonIcon } from "../atoms/PersonIcon";
+import { useRecoilValue } from "recoil";
+import { UserState, UserStateType } from "@/global-states/atoms";
 
 type Props = {
   uid: string;
@@ -17,11 +20,16 @@ export const UserCard = ({
   github,
   graduateYear,
 }: Props) => {
+  const myself = useRecoilValue<UserStateType>(UserState);
+
   return (
     <>
       <div className="font-caveat group group relative mb-2 h-full w-100 border overflow-hidden rounded-3xl bg-white lg:mb-3">
         <div className="flex justify-center">
-          <Image src="/avatar.gif" width={50} height={50} alt="avatar" />
+          <PersonIcon
+            originalIconImageSrc={myself?.imageUrl}
+            originalIconImageAlt={`${myself?.name}のアイコン`}
+          />
         </div>
         <div className="flex flex-col justify-center ">
           <p className="m-auto p-1">{name ? name : "No Name"}</p>

--- a/src/components/templetes/common/UserOrCorporate.tsx
+++ b/src/components/templetes/common/UserOrCorporate.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { useRouter } from "next/router";
+import { BsFillPersonFill } from "react-icons/bs";
 
 export const UserOrCorporate = () => {
   const router = useRouter();
@@ -13,19 +14,19 @@ export const UserOrCorporate = () => {
   };
 
   return (
-    <div className="flex-1 flex border-black/20 h-screen justify-center items-center pb-5">
+    <div className="flex-1 flex gap-8 border-black/20 h-screen justify-center items-center pb-5">
       <button
         onClick={directUser}
         className="rounded-2xl font-zen font-light bg-white mr-10 text-xl pb-10 mb-2 p-1 focus:bg-white/50 hover:bg-white/50"
       >
-        <Image src="/avatar.gif" width={400} height={400} alt="アバター" />
+        <BsFillPersonFill size={300} fill="gray" />
         <p>学生の方はこちら</p>
       </button>
       <button
         onClick={directCorporate}
         className="rounded-2xl font-zen font-light bg-white text-xl pb-10 mb-2 p-1 focus:bg-white/50 hover:bg-white/50"
       >
-        <Image src="/avatar.gif" width={400} height={400} alt="アバター" />
+        <BsFillPersonFill size={300} fill="gray" />
         <p>企業の方はこちら</p>
       </button>
     </div>

--- a/src/components/templetes/common/chat/Chat.tsx
+++ b/src/components/templetes/common/chat/Chat.tsx
@@ -13,6 +13,7 @@ import { ChatRoom } from "@/types/chatRoom";
 import Link from "next/link";
 import { isoToJstString } from "@/utils/date";
 import { ChatRepository } from "@/modules/chat/chat.repository";
+import { PersonIcon } from "@/components/atoms/PersonIcon";
 
 export const ChatPage = (): JSX.Element => {
   const socket = io(`${process.env.NEXT_PUBLIC_API_BASE_URL}`, {
@@ -87,12 +88,9 @@ export const ChatPage = (): JSX.Element => {
               room.id === roomId && "bg-[#0000001a]"
             }`}
           >
-            <Image
-              src={room.interlocutorImageUrl ?? "/avatar.gif"}
-              alt="対話相手のロゴ"
-              width={40}
-              height={40}
-              className="rounded-full border border-black"
+            <PersonIcon
+              originalIconImageSrc={room.interlocutorImageUrl}
+              originalIconImageAlt={`${room.interlocutorName}のアイコン`}
             />
             <div>
               <p className="min-h-[19px] text-[16px] font-black leading-[19px]">
@@ -138,12 +136,9 @@ export const ChatPage = (): JSX.Element => {
                 room.id === roomId && "bg-[#0000001a]"
               }`}
             >
-              <Image
-                src={room.interlocutorImageUrl ?? "/avatar.gif"}
-                alt="対話相手のロゴ"
-                width={40}
-                height={40}
-                className="rounded-full border border-black"
+              <PersonIcon
+                originalIconImageSrc={room.interlocutorImageUrl}
+                originalIconImageAlt={`${room.interlocutorName}のアイコン`}
               />
               <div>
                 <p className="min-h-[19px] text-[16px] font-black leading-[19px]">
@@ -172,14 +167,15 @@ export const ChatPage = (): JSX.Element => {
                 : { alignSelf: "start" }
             }
           >
-            <Image
-              src={chat.senderImage ?? "/avatar.gif"}
-              alt="人物アイコンのロゴ"
-              width={40}
-              height={40}
-              className={`${
+            <PersonIcon
+              originalIconImageSrc={chat.senderImage}
+              originalIconImageAlt={`${chat.senderName}のアイコン`}
+              originalIconClassName={`${
                 sender?.id === chat.senderId ? "hidden" : ""
               } rounded-full border border-black w-[40px] h-[40px]`}
+              defaultIconClassName={`${
+                sender?.id === chat.senderId ? "hidden" : ""
+              } rounded-full border border-black w-[40px] h-[40px] p-1`}
             />
             <div className="bg-white rounded-xl flex-col gap-[8px]">
               <p

--- a/src/components/templetes/layouts/UserLayout.tsx
+++ b/src/components/templetes/layouts/UserLayout.tsx
@@ -1,8 +1,7 @@
-import { Header } from "@/components/organisms/Header";
+import { MobileHeader } from "@/components/organisms/MobileHeader";
 import { UserState } from "@/global-states/atoms";
 import { useAuth } from "@/hooks/useAuth";
 import { axiosInstance } from "@/libs/axios";
-// import { SuccessModal } from "@/components/organisms/SuccessModal"
 import { ReactNode, useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { Loading } from "../common/Loading";
@@ -28,12 +27,11 @@ export const UserLayout = ({ children }: Props) => {
   return (
     <>
       <div className="sm:hidden">
-        <Header />
+        <MobileHeader />
         <main>{children}</main>
       </div>
 
       <div className="hidden sm:flex sm:flex-row">
-        {/* <Header /> */}
         <SideBar />
         <div className="flex-grow bg-gray-100 flex items-center justify-center">
           {children}

--- a/src/components/templetes/user/HomeScreen.tsx
+++ b/src/components/templetes/user/HomeScreen.tsx
@@ -1,23 +1,10 @@
-import { Header } from "@/components/organisms/Header";
 import { NarrowSearch } from "@/components/organisms/NarrowSerch";
-import { useState } from "react";
 import { RecruitList } from "../../organisms/RecruitList";
 
-export const HomeScreen = () => {
-  const [isOpen, setIsOpen] = useState(false);
-  const openModal = () => {
-    setIsOpen(true);
-  };
-
-  const closeModal = () => {
-    setIsOpen(false);
-  };
-
-  return (
-    <div className="flex flex-col">
-      <NarrowSearch />
-      <div className="border-b w-full "></div>
-      <RecruitList />
-    </div>
-  );
-};
+export const HomeScreen = () => (
+  <div className="flex flex-col">
+    <NarrowSearch />
+    <div className="border-b w-full "></div>
+    <RecruitList />
+  </div>
+);

--- a/src/components/templetes/user/UserProfile.tsx
+++ b/src/components/templetes/user/UserProfile.tsx
@@ -1,5 +1,4 @@
 import { UserState, UserStateType } from "@/global-states/atoms";
-import Image from "next/image";
 import { Fragment, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import Select from "react-select";
@@ -22,6 +21,7 @@ import { useRelatedRecruitsByUserId } from "@/hooks/useRelatedRecruitsByUserId";
 import { PiSignOutBold } from "react-icons/pi";
 import { authRepository } from "@/modules/auth/auth.repository";
 import { ConfirmModal } from "@/components/organisms/ConfirmModal";
+import { PersonIcon } from "@/components/atoms/PersonIcon";
 
 export const UserProfile = (): JSX.Element => {
   const router = useRouter();
@@ -119,6 +119,7 @@ export const UserProfile = (): JSX.Element => {
 
   return (
     <div className="flex flex-col items-center justify-center gap-28 text-[16px] pb-20 w-full">
+      {/* ログアウトボタン */}
       <button
         hidden={!isMyself}
         onClick={() => setIsConfirmOpen(true)}
@@ -140,18 +141,19 @@ export const UserProfile = (): JSX.Element => {
         modalMessage={signOutNoticeMessage}
         modalBgColor={signOutNoticeColor!}
       />
+      {/* プロフィール */}
       <form
         onSubmit={handleSubmit(onEditSubmit)}
         className="flex flex-col gap-20 w-3/4 sm:w-1/2 md:w-1/3"
       >
         <div className="mt-20 flex flex-col items-center gap-2">
           {/* アイコン */}
-          <Image
-            src={profileUser.imageUrl ?? "/avatar.gif"}
-            alt="人物アイコン"
-            width={900}
-            height={900}
-            className="rounded-full border border-black w-60 h-60"
+          <PersonIcon
+            originalIconImageSrc={profileUser.imageUrl}
+            originalIconImageAlt={`${profileUser.name}のアイコン`}
+            originalIconClassName="rounded-full border border-black w-40 h-40"
+            defaultIconFill="gray"
+            defaultIconClassName="w-40 h-40 rounded-full bg-white border border-black p-2 color-black-100"
             onClick={() => isMyself && setIsImageOpen(true)}
           />
           <EditProfileModal


### PR DESCRIPTION
## 概要
アイコンをreact-iconsで統一しました。

## スクショなど
<img width="1440" alt="スクリーンショット 2023-07-06 22 36 37" src="https://github.com/nagayamajun/unite-replace-front/assets/99397043/9c1af7d0-f3a4-4644-b2c7-cd0e23326c04">

<img width="257" alt="スクリーンショット 2023-07-06 22 35 49" src="https://github.com/nagayamajun/unite-replace-front/assets/99397043/70187e78-825d-4291-a306-dfb744c7f9f2">

<img width="376" alt="スクリーンショット 2023-07-06 22 36 01" src="https://github.com/nagayamajun/unite-replace-front/assets/99397043/48c3ea8e-ca16-4a21-aea6-1c525cee360c">

<img width="1438" alt="スクリーンショット 2023-07-06 20 23 21" src="https://github.com/nagayamajun/unite-replace-front/assets/99397043/42e05bcc-3e73-455e-b993-91ba9615d37a">

<img width="343" alt="スクリーンショット 2023-07-06 20 23 38" src="https://github.com/nagayamajun/unite-replace-front/assets/99397043/4ebbe069-1c13-4c6b-b112-44b6959df37e">
