### PR TITLE
[FE]　募集削除する, 情報を編集できるようにする, 条件検索をした時にUIが崩れるのを防ぐ,  新規認証/ログインのUI修正

### DIFF
--- a/src/components/atoms/PlainSelectInput.tsx
+++ b/src/components/atoms/PlainSelectInput.tsx
@@ -1,0 +1,65 @@
+import { FocusEventHandler, ReactNode } from "react";
+import { FieldErrors, FieldValues, UseFormRegister } from "react-hook-form";
+
+type ValidationRules = {
+  required?: boolean | string;
+  minLength?: number | { value: number; message: string };
+  pattern?: RegExp | { value: RegExp; message: string };
+};
+
+type PlainInputProps = {
+  labelText?: string;
+  inputType?: string;
+  placeholder?: string;
+  onBlur?: FocusEventHandler<HTMLSelectElement> | undefined;
+  register?: UseFormRegister<FieldValues>;
+  registerLabel: string;
+  rules?: ValidationRules;
+  errors?: FieldErrors<FieldValues>;
+  defaultValue?: string | number;
+  disabled?: boolean;
+  labelFont?: string;
+  inputFont?: string;
+  children?: ReactNode; // <option>要素を受け取るためにchildrenプロパティを追加
+};
+
+export const PlainSelectInput = ({
+  labelText,
+  onBlur,
+  register,
+  registerLabel,
+  rules,
+  errors,
+  defaultValue,
+  disabled,
+  labelFont = "text-xs sm:text-sm",
+  inputFont = "text-sm",
+  children, // childrenプロパティを受け取る
+}: PlainInputProps): JSX.Element => {
+  return (
+    <div className="flex flex-col gap-1 mb-4 w-full">
+      <label htmlFor={registerLabel} className={labelFont}>
+        {labelText}
+      </label>
+      <select
+        id={registerLabel}
+        defaultValue={defaultValue}
+        disabled={disabled}
+        {...(register && register(registerLabel ?? "", rules))}
+        onBlur={onBlur}
+        className={
+          "border border-gray-300 rounded-md shadow-sm p-2 sm:p-3 w-full outline-green-500 " +
+          inputFont
+        }
+      >
+        {children} 
+      </select>
+
+      {errors && errors[registerLabel] && (
+        <p className="text-xs font-light text-red-500">
+          {errors[registerLabel]?.message as ReactNode}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/atoms/PlainTextarea.tsx
+++ b/src/components/atoms/PlainTextarea.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { FocusEventHandler, ReactNode } from "react";
 import { FieldErrors, FieldValues, UseFormRegister } from "react-hook-form";
 
 type ValidationRulus = {
@@ -14,6 +14,8 @@ type PlainTextAreaProps = {
   registerLabel: string;
   errors?: FieldErrors<FieldValues>
   rules?: ValidationRulus
+  onBlur?: FocusEventHandler<HTMLInputElement> | undefined;
+  defaultValue?: string
 }
 
 //バリデーションを作成する
@@ -22,9 +24,11 @@ export const PlainTextArea = ({
   labelText,
   placeholder,
   register,
+  onBlur,
   registerLabel,
   errors,
-  rules
+  rules,
+  defaultValue,
 }: PlainTextAreaProps): JSX.Element => {
 
   return (
@@ -34,6 +38,7 @@ export const PlainTextArea = ({
         <textarea
           id="textarea"
           placeholder={placeholder}
+          defaultValue={defaultValue}
           className="border border-gray-300 h-32 rounded-md shadow-sm w-full outline-green-500 text-sm p-2"
           {...(register && register(registerLabel ?? "",
             rules

--- a/src/components/organisms/EmailAndPasswordForm.tsx
+++ b/src/components/organisms/EmailAndPasswordForm.tsx
@@ -9,9 +9,7 @@ export const EmailAndPasswordForm: React.FC<Props> = ({ onSubmit, buttonText }):
 
   const { handleSubmit, register, formState: {errors}} = useForm()
   return (
-
-    <>
-      <form className="flex-col sm:w-1/2 w-3/5" onSubmit={handleSubmit(onSubmit)}>
+      <form className="flex-col w-full" onSubmit={handleSubmit(onSubmit)}>
         <AuthInput
           labelText="メールアドレス"
           placeholder="example@gmail.com"
@@ -41,7 +39,6 @@ export const EmailAndPasswordForm: React.FC<Props> = ({ onSubmit, buttonText }):
           </button>
         </div>
       </form>
-    </>
   )
 }
 

--- a/src/components/organisms/RecruitList.tsx
+++ b/src/components/organisms/RecruitList.tsx
@@ -25,9 +25,9 @@ export const RecruitList = (): JSX.Element => {
   };
 
   return (
-    <div className="bg-gray-100 pt-10 h-auto">
+    <div className="bg-gray-100 pt-10 min-h-screen">
       <div className="grid mx-12 sm:mx-20 gap-x-20 gap-y-8 sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2">
-          {filteredRecruits.length == 0 && <p>条件に一致する募集はありません</p>}
+          {filteredRecruits.length == 0 && <p className="font-bold">条件に一致する募集はありません</p>}
           { filteredRecruits?.map((recruit: RecruitCardProps) => {
             if (user?.id !== recruit?.recruiter?.id) {
               return (

--- a/src/components/templetes/user/EditRecruit.tsx
+++ b/src/components/templetes/user/EditRecruit.tsx
@@ -1,0 +1,186 @@
+import { recruitRepository } from "@/modules/recruit/recruit.repository";
+import { Recruit } from "@/types/recruit";
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react";
+import { Loading } from "../common/Loading";
+import { Controller, useForm } from "react-hook-form";
+import { PlainInput } from "@/components/atoms/PlainInput";
+import { PlainTextArea } from "@/components/atoms/PlainTextarea";
+import { PlainSelectInput } from "@/components/atoms/PlainSelectInput";
+import { FormField } from "@/components/atoms/FormField";
+import { EditProfileModal } from "@/components/organisms/EditProfileModal";
+import Select from "react-select";
+import { ProgramingSkillOptions } from "@/modules/programingSkill/programingSkill.repository";
+import { FormRecruitData } from "./AddRecruit";
+import { ConfirmModal } from "@/types/confirmModal";
+import { SuccessOrFailureModal } from "@/components/organisms/SuccessOrFailureModal";
+import Link from "next/link";
+
+export const EditRecruit = () => {
+  const router = useRouter();
+  const { id }  = router.query;
+  const { register, handleSubmit, control, reset } = useForm();
+
+  const [ isLoading, setIsLoading ] = useState<boolean>(true)
+  const [ recruit, setRecruit ] = useState<Recruit>();
+
+  const [isSkillOpen, setIsSkillOpen] = useState(false);
+
+  //失敗/成功notice
+  const [isNoticeOpen, setIsNoticeOpen] = useState(false);
+  const [noticeMessage, setNoticeMessage] = useState("");
+  const [noticeColor, setNoticeColor] = useState<boolean>();
+  const closeNotice = () => setIsNoticeOpen(false);
+
+
+  useEffect(() =>{
+    (async () => {
+      const fetchedRecruit = await recruitRepository.getRecruitById(id as string);
+      setRecruit(fetchedRecruit);
+      setIsLoading(false)
+    })()
+  },[])
+
+  if(isLoading || !recruit) return <Loading />
+
+  const onEditSubmit = async(input: any): Promise<void> => {
+    await recruitRepository.editRecruit(recruit.id, input)
+    .then((result) => {
+      //notice表示
+      setIsNoticeOpen(true);
+      setNoticeMessage(result.message);
+      setNoticeColor(result.success);
+
+      setIsSkillOpen(false)
+
+      reset({});
+
+      setTimeout(() => {
+        setIsNoticeOpen(false)
+      },
+        result.success ? 2000 : 4000
+      )
+    })
+  }
+
+  return(
+    <div className=" min-h-screen w-96 space-y-6 my-12">
+      <h2 className="text-center font-bold ">募集情報編集</h2>
+      <form
+       onSubmit={handleSubmit(onEditSubmit)}
+      >
+        <PlainInput
+          labelText="ハッカソン名"
+          placeholder="ハッカソン名を入力してください"
+          onBlur={handleSubmit(onEditSubmit)}
+          register={register}
+          defaultValue={recruit.hackthonName}
+          registerLabel="hackthonName" 
+          inputFont="text-sm sm:text-base"
+        />
+
+        <PlainInput
+          labelText="見出しを一言"
+          placeholder="ハッカソン名を入力してください"
+          onBlur={handleSubmit(onEditSubmit)}
+          register={register}
+          defaultValue={recruit.headline}
+          registerLabel="headline" 
+          inputFont="text-sm sm:text-base"
+        />
+
+        <PlainTextArea
+          registerLabel="details"
+          labelText="募集内容の詳細"
+          placeholder="募集内容について細かくご記入ください"
+          register={register}
+          defaultValue={recruit.details}
+          onBlur={handleSubmit(onEditSubmit)}
+        />
+
+        <PlainSelectInput
+          registerLabel="numberOfApplicants"
+          register={register}
+          labelText="募集人数を選択"
+          defaultValue={recruit.numberOfApplicants}
+          onBlur={handleSubmit(onEditSubmit)}
+        >
+          <option value="1">1人</option>
+          <option value="2">2人</option>
+          <option value="3">3人</option>
+          <option value="4">4人</option>
+          <option value="5">5人</option>
+          <option value="6">6人</option>
+        </PlainSelectInput>
+
+        <PlainInput
+          registerLabel="hackathonUrl"
+          inputType="url"
+          labelText="ハッカソンのURL"
+          placeholder="http://sample.jp"
+          register={register}
+          defaultValue={recruit.hackathonUrl}
+          onBlur={handleSubmit(onEditSubmit)}
+        />
+
+        <PlainInput
+          registerLabel="developmentPeriod"
+          labelText="開発・ハッカソン期間"
+          placeholder="2023/4/29~2023/5/14"
+          register={register}
+        />
+
+        {/* プログラミングスキル */}
+        <FormField
+          labelText="プログラミングスキル"
+          editable={true}
+          onCLick={() => setIsSkillOpen(true)}
+        >
+          <div className="flex flex-wrap gap-4">
+            {recruit.programingSkills.map((skill) => (
+              <div
+                key={skill}
+                className="px-8 py-2 rounded-3xl bg-gray-200 text-base"
+              >
+                {skill}
+              </div>
+            ))}
+          </div>
+        </FormField>
+        <EditProfileModal
+          isOpen={isSkillOpen}
+          setIsOpen={setIsSkillOpen}
+          onClickOk={handleSubmit(onEditSubmit)}
+        >
+          <div className="flex flex-col gap-6">
+            <div>プログラミングスキル</div>
+            <Controller
+              name="programingSkills"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  isMulti
+                  options={ProgramingSkillOptions}
+                  onChange={(selectedSkills) => {
+                    field.onChange(selectedSkills.map((skill) => skill.value));
+                  }}
+                  placeholder="スキル名を選択してください (複数選択可)"
+                />
+              )}
+            />
+          </div>
+        </EditProfileModal>
+      </form>
+      <div className="flex flex-col justify-end items-end">
+        <Link href={`/recruit/${recruit.id}/ownRecruitDetail`}>戻る</Link>
+      </div>
+      {/* 成功/失敗notice */}
+      <SuccessOrFailureModal
+        isOpen={isNoticeOpen}
+        closeModal={closeNotice}
+        modalMessage={noticeMessage}
+        modalBgColor={noticeColor!}
+      />
+    </div>
+  )
+}

--- a/src/components/templetes/user/HomeScreen.tsx
+++ b/src/components/templetes/user/HomeScreen.tsx
@@ -14,7 +14,7 @@ export const HomeScreen = () => {
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col w-full">
       <NarrowSearch />
       <div className="border-b w-full "></div>
       <RecruitList />

--- a/src/components/templetes/user/OwnRecruitDetail.tsx
+++ b/src/components/templetes/user/OwnRecruitDetail.tsx
@@ -1,58 +1,111 @@
 import { Recruit } from "@/types/recruit";
 import Link from "next/link";
-import { format } from 'date-fns'
 import React, { useEffect, useState } from "react";
 import { userRecruitParticipantRepository } from "@/modules/user-recruit-participant/userRecruitParticipant.repository";
 import { useRouter } from "next/router";
 import { recruitRepository } from "@/modules/recruit/recruit.repository";
 import { UserRecruitParticipant } from "@/types/UserRecruitParticipant";
-
+import { Loading } from "../common/Loading";
+import { SuccessOrFailureModal } from "@/components/organisms/SuccessOrFailureModal";
+import { AiFillDelete } from 'react-icons/ai'
 
 
 export const OwnRecruitDetail: React.FC = ()  => {
   const router = useRouter();
-  const { id } = router.query
+  const { id } = router.query;
 
-  const [ recruit, setRecruit ] = useState<Recruit>()
+  const [ recruit, setRecruit ] = useState<Recruit>();
+  const [ isLoading, setIsLoading ] = useState<boolean>();
   
+  //モーダル関係
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const [color, setColor] = useState<boolean>();
+  const closeModal = () => setIsOpen(false);
+
   useEffect(() =>{
     (async () => {
       const fetchedRecruit = await recruitRepository.getRecruitById(id as string);
       setRecruit(fetchedRecruit);
+      setIsLoading(false)
     })()
   },[])
 
-  const handleUploadProduct = () => {
-    router.push(`/product/uploadProduct?recruitId=${recruit?.id}`);
-  };
+  if (isLoading || !recruit) return <Loading />
 
   const approveApplication = async(uid: string) => {
-    await userRecruitParticipantRepository.approveParticipant(uid);
-    router.reload();
+    await userRecruitParticipantRepository.approveParticipant(uid)
+    .then((result) => {
+      if (result) {
+        setIsOpen(true);
+        setModalMessage(result.message)
+        setColor(result.success)
+
+        setTimeout(() => {
+          router.reload()
+        },
+        result.success ? 2000 : 4000
+        )
+      }
+    });
   }
 
   const rejectApplication = async(uid: string) => {
-    await userRecruitParticipantRepository.rejectParticipant(uid);
-    router.reload();
+    await userRecruitParticipantRepository.rejectParticipant(uid)
+    .then((result) => {
+      if (result) {
+        setIsOpen(true);
+        setModalMessage(result.message)
+        setColor(result.success)
+
+        setTimeout(() => {
+          router.reload()
+        },
+        result.success ? 2000 : 4000
+        )
+      }
+    });
+  }
+
+  const deleteRecruit = async() => {
+    console.log(recruit.id)
+    await recruitRepository.deleteRecruit(recruit.id).then((result) => {
+      if (result) {
+        setIsOpen(true);
+        setModalMessage(result.message)
+        setColor(result.success)
+
+        setTimeout(() => {
+          router.push('/homeScreen')
+        }, 
+        result.success ? 2000 : 4000
+        )
+      }
+    })
+    
   }
 
   return (
     <div className="h-full flex justify-center items-center sm:bg-gray-100">
       <div className="flex flex-col items-center w-4/5 sm:w-base md:w-sm  bg-white rounded-sm">
-        <div className="h-20 sm:h-40 w-full flex flex-col justify-center items-center bg-gradient-to-r from-green-300 to-pink-300 text-white rounded-sm rounded-b-none">
+        <div className="h-20 sm:h-40 w-full flex flex-col justify-center items-center bg-gradient-to-r from-green-300 to-pink-300 text-white rounded-sm rounded-b-none relative">
+          {/* 削除ボタン */}
+          <button onClick={deleteRecruit} className="absolute top-4 right-4 text-red-500">
+            <AiFillDelete size={30} />
+          </button>
           {/* ハッカソン名 */}
-          <h1 className="text-3xl sm:text-4xl font-bold text-center">{recruit?.hackthonName}</h1>
+          <h1 className="text-3xl sm:text-4xl font-bold text-center">{recruit.hackthonName}</h1>
         </div>
 
         <div className="w-full sm:w-4/5 flex flex-col">
           <div className="flex items-center justify-center h-20 sm:h-24 border-b border-gray-200 text-lg">
-            {recruit?.headline}
+            {recruit.headline}
           </div>
           {/* プログラミングスキル */}
           <div className="flex flex-col justify-start items-start border-b pl-5 m-2 sm:pl-0 pb-5">
             <p className="my-2 font-semibold">募集スキル</p>
             <div className="break-all flex-row flex flex-wrap">
-              {recruit?.programingSkills?.map((skill, index) => (
+              {recruit.programingSkills?.map((skill, index) => (
                   <p key={index} className="bg-gray-50 border rounded-2xl m-1 px-3 overflow-hidden text-overflow-ellipsis">{skill}</p>
               ))}
             </div>
@@ -60,23 +113,23 @@ export const OwnRecruitDetail: React.FC = ()  => {
           <div className="flex flex-col sm:flex-row justify-between border-b pl-5 sm:pl-0 m-2 pb-5">
             <div className="mb-2 w-full">
               <p className="font-semibold">開発期間</p>
-              <div>{recruit?.developmentPeriod}</div>
+              <div>{recruit.developmentPeriod}</div>
             </div>
             <div className="w-full">
               <p className="font-semibold">募集人数</p>
-              <div><span className="bg-green-400 p-1 rounded-md text-white">{recruit?.numberOfApplicants}</span> 人</div>
+              <div><span className="bg-green-400 py-1 px-2 rounded-md text-white">{recruit.numberOfApplicants}</span> 人</div>
             </div>
           </div>
 
           <div className="border-b pl-5 sm:pl-0 m-2 pb-5">
             {/* 募集の詳細 */}
             <p className="font-semibold mb-2">詳細</p>
-            <div className="leading-snug border border-gray-200 rounded p-3">{recruit?.details}</div>
+            <div className="leading-snug border border-gray-200 rounded p-3">{recruit.details}</div>
           </div>
 
           <div className="border-b pl-5 sm:pl-0 m-2 pb-5">
             <p className="font-semibold mb-2">ハッカソンURL</p>
-            <div className="leading-snug border border-gray-200 rounded p-2">{recruit?.hackathonUrl}</div>
+            <div className="leading-snug border border-gray-200 rounded p-2">{recruit.hackathonUrl}</div>
           </div>
 
           <div></div>
@@ -84,8 +137,8 @@ export const OwnRecruitDetail: React.FC = ()  => {
           {/* <div className="flex flex-col w-full"> */}
           <div className="border-b pl-5 sm:pl-0 m-2 pb-5">
             <p className="font-semibold mb-2">参加者</p>
-            {recruit?.userRecruitParticipant?.length === 0 && <p>参加者はまだいません</p>}
-            {recruit?.userRecruitParticipant?.map((participant: UserRecruitParticipant, index) => {
+            {recruit.userRecruitParticipant?.length === 0 && <p>参加者はまだいません</p>}
+            {recruit.userRecruitParticipant?.map((participant: UserRecruitParticipant, index) => {
               if (participant.isApproved) {
                 return (
                   <div key={index}>
@@ -100,8 +153,8 @@ export const OwnRecruitDetail: React.FC = ()  => {
           <div className="border-b pl-5 sm:pl-0 m-2 pb-5">
             <p className="font-semibold mb-2">参加希望者一覧</p>
             {/* ここは応募してくれた方を一覧表示する */}
-            {recruit?.userRecruitParticipant?.length === 0 && <p>希望者はまだいません</p>}
-            {recruit?.userRecruitParticipant?.map((participant: UserRecruitParticipant, index) => {
+            {recruit.userRecruitParticipant?.length === 0 && <p>希望者はまだいません</p>}
+            {recruit.userRecruitParticipant?.map((participant: UserRecruitParticipant, index) => {
               if (!participant.isApproved) {
                 return (
                   <div key={index} className="flex flex-row justify-between">
@@ -117,23 +170,32 @@ export const OwnRecruitDetail: React.FC = ()  => {
           </div>
         </div>
 
-        <div className="flex flex-row items-center justify-center w-full my-10">
+        <div className="flex items-center justify-center w-full my-10">
           {
             recruit?.product.length !== 0 ? (
-              <Link href={`/product/${recruit?.product[0]?.id}`} className="bg-green-400 hover:bg-green-500 px-6 py-4 rounded-md text-white font-semibold">Productページへ</Link>
+              <div className="w-4/5 flex flex-row items-center justify-between">
+                <Link href={`/recruit/editRecruit?id=${recruit.id}`} className="bg-green-400 hover:bg-green-500 px-4 py-4 rounded-md text-white font-semibold">募集情報を編集する</Link>
+                <Link href={`/product/${recruit.product[0]?.id}`} className="bg-green-400 hover:bg-green-500 px-6 py-4 rounded-md text-white font-semibold">Productページへ</Link>
+              </div>
             ) : (
-              <div className="w-1/3 flex justify-center items-center">
-                <button onClick={handleUploadProduct} className="bg-green-400 px-12 py-2 rounded-md text-white">UPLOAD</button>
+              <div className="w-4/5 flex flex-row items-center justify-between">
+                <Link href={`/recruit/editRecruit?id=${recruit.id}`} className="bg-green-400 hover:bg-green-500 px-2 py-2 rounded-md text-white font-semibold">募集情報を編集する</Link>
+                <Link href={`/product/uploadProduct?recruitId=${recruit?.id}`} className="bg-green-400 hover:bg-green-500 px-2 py-2 rounded-md text-white font-semibold">UPLOADする</Link>
               </div>
             )
           }
         </div>
       </div>
+
+      <SuccessOrFailureModal
+        isOpen={isOpen}
+        closeModal={closeModal}
+        modalMessage={modalMessage}
+        modalBgColor={color!}
+      />
     </div>
   )
 }
 
- //まだできていないこと
+ //リファクタ
  //募集人数を動的に変更
-
- //src/pages/product/[recruitId]/uploadProduct.tsx

--- a/src/components/templetes/user/RecruitDetail.tsx
+++ b/src/components/templetes/user/RecruitDetail.tsx
@@ -18,6 +18,15 @@ export const RecruitDetail: React.FC = () => {
   const { id } = router.query;
   const [ recruit, setRecruit ] = useState<Recruit>();
 
+  const [ isParticipant, setIsParticipant ] = useState<boolean>()
+  //いいねをしているかしていないかの判定に利用する
+  const isLiked = recruit?.userToRecruitLikes?.some((like) => like.userId === user?.id);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const [color, setColor] = useState<boolean>();
+  const closeModal = () => setIsOpen(false);
+
   useEffect(() => {
     (async () => {
       const fetchedRecruit = await recruitRepository.getRecruitById(id as string)
@@ -25,22 +34,19 @@ export const RecruitDetail: React.FC = () => {
     })()
   }, [])
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [modalMessage, setModalMessage] = useState("");
-  const [color, setColor] = useState<boolean>();
-  const closeModal = () => setIsOpen(false);
-  const isParticipant = recruit?.userRecruitParticipant?.some(participant => participant.userId == user?.id);
-  //いいねをしているかしていないかの判定に利用する
-  const isLiked = recruit?.userToRecruitLikes?.some((like) => like.userId === user?.id);
+  useEffect(() => {
+    const checkParticipant = recruit?.userRecruitParticipant?.some(
+      participant => participant.userId === user?.id
+    );
+    setIsParticipant(checkParticipant);
+  }, [recruit]);
 
   const applyForJoin = async() => {
     await userRecruitParticipantRepository.applyForJoin(recruit?.id as string);
-    router.reload()
+    setIsParticipant(true)
   }
 
   const onApplyFor = async () => {
-    if (!recruit?.id) throw new Error('recruitIdが確認できません')
-
     UserRecruitApplicationRepository.applyFor(recruit?.id!)
       .then((applicationWithRoomId) => {
         router.push(`/chat/${applicationWithRoomId.roomId}`);
@@ -57,7 +63,7 @@ export const RecruitDetail: React.FC = () => {
       });
   };
 
-  if (isLiked === undefined) return <Loading/>
+  if (isLiked === undefined || isParticipant === undefined) return <Loading/>
 
   return (
     <div className="h-full min-h-screen flex justify-center items-center sm:bg-gray-100  text-gray-600">

--- a/src/components/templetes/user/SignIn.tsx
+++ b/src/components/templetes/user/SignIn.tsx
@@ -68,50 +68,56 @@ export const SignIn: React.FC = (): JSX.Element => {
   };
 
   return (
-    <div className="flex flex-col justify-center items-center h-screen mt-5">
-      <EmailAndPasswordForm onSubmit={onSubmit} buttonText="ログイン" />
-      <div className="flex sm:w-1/2 w-3/5 my-6">
-        <div className="h-0 w-1/3 border-b border-black mt-3"></div>
-        <div className="flex justify-center items-center w-1/3">
-          <p>または</p>
+    <div className="flex flex-col justify-center items-center h-screen">
+      <div className="flex flex-col items-center w-4/5 sm:w-base">
+        <h1 className="text-2xl sm:text-3xl font-bold">
+          <span className="text-green-700">U</span>N
+          <span className="text-pink-400">I</span>TE
+        </h1>
+        <EmailAndPasswordForm onSubmit={onSubmit} buttonText="ログイン" />
+        <div className="flex  w-full my-6">
+          <div className="h-0 w-1/3 border-b border-black mt-3"></div>
+          <div className="flex justify-center items-center w-1/3">
+            <p>または</p>
+          </div>
+          <div className="h-0 w-1/3 border-b border-black mt-3"></div>
         </div>
-        <div className="h-0 w-1/3 border-b border-black mt-3"></div>
-      </div>
 
-      <div className="flex col items-center justify-center sm:w-1/2 w-3/5 ">
-        <div className="w-full ">
-          <AuthButton
-            src="/home.png"
-            onClick={async () =>
-              onClickGoogleOrGithub(authRepository.signInWithGoogle())
-            }
-          >
-            Continue with Google
-          </AuthButton>
-          <AuthButton
-            src="/github-mark.png"
-            onClick={async () =>
-              onClickGoogleOrGithub(authRepository.signInWithGithub())
-            }
-          >
-            Continue with GitHub
-          </AuthButton>
+        <div className="flex col items-center justify-center w-full ">
+          <div className="w-full ">
+            <AuthButton
+              src="/home.png"
+              onClick={async () =>
+                onClickGoogleOrGithub(authRepository.signInWithGoogle())
+              }
+            >
+              Continue with Google
+            </AuthButton>
+            <AuthButton
+              src="/github-mark.png"
+              onClick={async () =>
+                onClickGoogleOrGithub(authRepository.signInWithGithub())
+              }
+            >
+              Continue with GitHub
+            </AuthButton>
+          </div>
         </div>
-      </div>
 
-      <div className="flex justify-center">
-        <p className="text-sm sm:text-base">まだアカウントをお持ちでない方　</p>
-        <Link href="/signUp" className="font-bold">
-          登録
-        </Link>
-      </div>
+        <div className="flex justify-center">
+          <p className="text-sm sm:text-base">まだアカウントをお持ちでない方　</p>
+          <Link href="/signUp" className="font-bold">
+            登録
+          </Link>
+        </div>
 
-      <SuccessOrFailureModal
-        isOpen={isOpen}
-        closeModal={closeModal}
-        modalMessage={modalMessage}
-        modalBgColor={color!}
-      />
+        <SuccessOrFailureModal
+          isOpen={isOpen}
+          closeModal={closeModal}
+          modalMessage={modalMessage}
+          modalBgColor={color!}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/templetes/user/SignUp.tsx
+++ b/src/components/templetes/user/SignUp.tsx
@@ -68,9 +68,14 @@ export const SignUp = () => {
   };
 
   return (
-    <div className="flex flex-col items-center h-screen mt-5">
+    <div className="flex flex-col justify-center items-center h-screen">
+      <div className="flex flex-col items-center w-4/5 sm:w-base">
+      <h1 className="text-2xl sm:text-3xl font-bold">
+          <span className="text-green-700">U</span>N
+          <span className="text-pink-400">I</span>TE
+        </h1>
       <EmailAndPasswordForm onSubmit={onSubmit} buttonText="新規登録" />
-      <div className="flex sm:w-1/2 w-3/5 my-6">
+      <div className="flex  w-full my-6">
         <div className="h-0 w-1/3 border-b border-black mt-3"></div>
         <div className="flex justify-center items-center w-1/3">
           <p>または</p>
@@ -78,7 +83,7 @@ export const SignUp = () => {
         <div className="h-0 w-1/3 border-b border-black mt-3"></div>
       </div>
 
-      <div className="flex col items-center justify-center sm:w-1/2 w-3/5 ">
+      <div className="flex col items-center justify-center w-full ">
         <div className="w-full ">
           <AuthButton
             src="/home.png"
@@ -112,6 +117,7 @@ export const SignUp = () => {
         modalMessage={modalMessage}
         modalBgColor={color!}
       />
+    </div>
     </div>
   );
 };

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -11,7 +11,19 @@ export const MAIL_USED_IN_PROVIDER_EXISTS =
   "選択した認証プロバイダで使用されているメールアドレスが、本サービスですでに登録済みである可能性があります。";
 
 export const FAIL_TO_PUSH_LIKE = "いいねを押すことに失敗しました。";
-export const FAIL_TO_DELETE_LIKE = "いいねを取り消すことに失敗しました。"
+export const FAIL_TO_DELETE_LIKE = "いいねを取り消すことに失敗しました。";
 
 export const SUCCESS_IN_UPDATE_USER = "ユーザー情報が更新されました。";
 export const FAIL_TO_UPDATE_USER = "ユーザー情報の更新に失敗しました。";
+
+export const SUCCESS_TO_APPROVE_PARTICIPANT = "承認に成功しました。";
+export const FAIL_TO_APPROVE_PARTICIPANT = "承認に失敗しました。"
+
+export const SUCCESS_TO_REJECT_PARTICIPANT = "拒否に成功しました。";
+export const FAIL_TO_REJECT_PARTICIPANT = "拒否に失敗しました。"
+
+export const SUCCESS_TO_UPDATE_RECRUIT = "募集情報を更新しました。"
+export const FAIL_TO_UPDATE_RECRUIT = "募集情報の更新に失敗しました。"
+
+export const SUCCESS_TO_DELETE_RECRUIT = "募集を削除しました。"
+export const FAIL_TO_DELETE_RECRUIT = "募集の削除に失敗しました。"

--- a/src/modules/recruit/recruit.repository.ts
+++ b/src/modules/recruit/recruit.repository.ts
@@ -2,6 +2,7 @@ import { FormRecruitData } from "@/components/templetes/user/AddRecruit";
 import { Recruit } from "@/types/recruit";
 import { axiosInstance } from "@/libs/axios";
 import { ConfirmModal } from "@/types/confirmModal";
+import { FAIL_TO_DELETE_RECRUIT, FAIL_TO_UPDATE_RECRUIT, SUCCESS_TO_DELETE_RECRUIT, SUCCESS_TO_UPDATE_RECRUIT } from "@/constants/constants";
 
 export const recruitRepository = {
   //募集の一覧取得
@@ -102,5 +103,43 @@ export const recruitRepository = {
       return { message: "募集作成に失敗しました。", success: false };
     }
   },
+
+  //募集情報の編集
+  async editRecruit(
+    id: string,
+    input: FormRecruitData,
+  ): Promise<ConfirmModal> {
+    try {
+      await axiosInstance.put(`/user-recruit/${id}`, input);
+      return {
+        success: true,
+        message: SUCCESS_TO_UPDATE_RECRUIT
+      }
+    } catch (error) {
+      const isTypeSafeError = error instanceof Error;
+      return {
+        success: false,
+        message: `${FAIL_TO_UPDATE_RECRUIT} ${isTypeSafeError ? error.message : ""}`
+      }
+    }
+  },
+
   //募集の削除
+  async deleteRecruit(id: string): Promise<ConfirmModal> {
+    try {
+      await axiosInstance.delete(`/user-recruit/${id}`)
+      return {
+        success: true,
+        message: SUCCESS_TO_DELETE_RECRUIT
+      }
+    } catch (error) {
+      const isTypeSafeError = error instanceof Error
+      return {
+        success: false,
+        message: `${FAIL_TO_DELETE_RECRUIT}\n${isTypeSafeError ? error.message : ""}`
+      }
+    }
+  }
+
+
 };

--- a/src/modules/user-recruit-participant/userRecruitParticipant.repository.ts
+++ b/src/modules/user-recruit-participant/userRecruitParticipant.repository.ts
@@ -1,4 +1,7 @@
+import { FAIL_TO_APPROVE_PARTICIPANT, FAIL_TO_REJECT_PARTICIPANT, SUCCESS_TO_APPROVE_PARTICIPANT, SUCCESS_TO_REJECT_PARTICIPANT } from "@/constants/constants";
 import { axiosInstance } from "@/libs/axios";
+import { ConfirmModal } from "@/types/confirmModal";
+import { type } from "os";
 
 export const userRecruitParticipantRepository = {
   //参加依頼を送る
@@ -22,20 +25,34 @@ export const userRecruitParticipantRepository = {
     }
   },
 
-  async  approveParticipant(id: string) {
+  async  approveParticipant(id: string): Promise<ConfirmModal> {
     try {
       await axiosInstance.put(`/user-recruit-participant/${id}/approve`)
-      return{ message: '承認しました。'}
-    } catch (error) {
-      throw new Error(`承認することができませんでした。${error}`)
+      return {
+        message: `${SUCCESS_TO_APPROVE_PARTICIPANT}`,
+        success: true
+      }
+    } catch (error: unknown) {
+      const isTypeSafeError = error instanceof Error;
+      return {
+        success: false,
+        message: `${FAIL_TO_APPROVE_PARTICIPANT}\n${isTypeSafeError ? error.message : ""}`
+      }
     }
   },
 
-  async rejectParticipant(id: string) {
+  async rejectParticipant(id: string): Promise<ConfirmModal> {
     try {
       await axiosInstance.delete(`/user-recruit-participant/${id}/reject`)
+      return {
+        message: `${SUCCESS_TO_REJECT_PARTICIPANT}`,
+        success: true
+      }
     } catch (error) {
-      throw new Error(`拒否することができませんでした。 ${error}`)
+      const isTypeSafeError = error instanceof Error
+      return {
+        message: `${FAIL_TO_REJECT_PARTICIPANT}\n${isTypeSafeError ? error.message : ""}`
+      }
     }
   }
 };

--- a/src/pages/recruit/editRecruit.tsx
+++ b/src/pages/recruit/editRecruit.tsx
@@ -1,0 +1,9 @@
+import { UserLayout } from "@/components/templetes/layouts/UserLayout"
+import { EditRecruit } from "@/components/templetes/user/EditRecruit"
+import { ReactElement } from "react"
+
+const EditRecruitPage = () => <EditRecruit />
+
+EditRecruitPage.getLayout = (page: ReactElement) => <UserLayout>{page}</UserLayout>
+
+export default EditRecruitPage


### PR DESCRIPTION
--概要
<img width="1728" alt="スクリーンショット 2023-07-07 15 07 27" src="https://github.com/nagayamajun/unite-replace-front/assets/85071324/290841c9-9bad-4d7b-b7e2-b341d26ff833">

以上の三つのタスクを寝ぼけたままやってブランチ切らないで作業してしまいまいた🙇

--確認して欲しいこと
1.募集は削除することはできるか?, 情報を編集することができるか?
確認方法
募集を作成する ->　募集管理者ページに編集ページに飛ぶリンクがあるのでそこで作業して確認 -> productを作成する ->productを作った状態で募集を削除することができるか確認

2.条件検索をした場合のUI確認
確認方法
条件に募集が引っかからないような条件を指定する -> その際にUIが崩れていないか確認
*できていない事
queryでの条件検索に変更する(流石にブランチでの作業が大きくなると思ったのと一応動作的に問題はないのでブランチ切り直して後々やります)

3.新規ログイン
UIの微修正のみですのでご確認ください🙇
<img width="1728" alt="スクリーンショット 2023-07-07 15 14 03" src="https://github.com/nagayamajun/unite-replace-front/assets/85071324/ce15f75b-8670-487b-8dbc-71ccc07fa052">
<img width="1728" alt="スクリーンショット 2023-07-07 15 14 20" src="https://github.com/nagayamajun/unite-replace-front/assets/85071324/a891a0ad-93fa-4e4f-84b3-cebbcfdcdb0e">

