### PR TITLE
登録時 (初回ログイン時) とユーザー名が未登録の場合、ユーザー情報登録フォームに遷移

### DIFF
--- a/src/components/atoms/GraduationYearRadio.tsx
+++ b/src/components/atoms/GraduationYearRadio.tsx
@@ -1,14 +1,15 @@
-import { useGraduationYears } from "@/hooks/useGraduationYears";
 import { RadioGroup } from "@headlessui/react";
 import { Control, Controller, FieldValues } from "react-hook-form";
 
 type GraduationYearRadioProps = {
   control: Control<FieldValues, any>;
+  defaultValue?: string;
   defaultChipColor?: string;
 };
 
 export const GraduationYearRadio = ({
   control,
+  defaultValue,
   defaultChipColor = "bg-white",
 }: GraduationYearRadioProps): JSX.Element => {
   // const { graduationYears } = useGraduationYears();
@@ -20,11 +21,13 @@ export const GraduationYearRadio = ({
 
   //ここは切り離して別ファイルで管理する。
   //そもそも企業がフィルターかけるようにした方がいいからサーバーサイドでテーブルとして持たせる？
-  const years = ["23卒", "24卒", "25卒", "26卒", "27卒", "その他" ]
+  const years = ["23卒", "24卒", "25卒", "26卒", "27卒", "その他"];
 
   return (
     <div className="flex flex-col gap-6">
-      <label htmlFor="radio" className="text-xs sm:text-sm">卒業予定年度</label>
+      <label htmlFor="radio" className="text-xs sm:text-sm">
+        卒業予定年度
+      </label>
       <Controller
         name="graduateYear"
         control={control}
@@ -33,6 +36,7 @@ export const GraduationYearRadio = ({
             onChange={(graduateYear) => {
               field.onChange(graduateYear);
             }}
+            defaultValue={defaultValue}
           >
             <div id="radio" className="flex flex-wrap gap-8">
               {years.length > 1 &&
@@ -42,7 +46,9 @@ export const GraduationYearRadio = ({
                       return (
                         <span
                           className={`${
-                            checked ? "bg-green-400 border-none text-white" : defaultChipColor
+                            checked
+                              ? "bg-green-400 border-none text-white"
+                              : defaultChipColor
                           } sm:px-8 sm:py-2 py-1 px-6 rounded-3xl border border-gray-300 text-gray-500`}
                         >
                           {graduateYear}

--- a/src/components/atoms/PlainTextarea.tsx
+++ b/src/components/atoms/PlainTextarea.tsx
@@ -5,42 +5,44 @@ type ValidationRulus = {
   required?: boolean | string;
   minLength?: number | { value: number; message: string };
   pattern?: RegExp | { value: RegExp; message: string };
-}
+};
 
 type PlainTextAreaProps = {
   labelText?: string;
   placeholder?: string;
+  defaultValue?: string;
   register?: UseFormRegister<FieldValues>;
   registerLabel: string;
-  errors?: FieldErrors<FieldValues>
-  rules?: ValidationRulus
-}
+  errors?: FieldErrors<FieldValues>;
+  rules?: ValidationRulus;
+};
 
 //バリデーションを作成する
 
 export const PlainTextArea = ({
   labelText,
   placeholder,
+  defaultValue,
   register,
   registerLabel,
   errors,
-  rules
-}: PlainTextAreaProps): JSX.Element => {
-
-  return (
-    <>
-      <div className="flex flex-col gap-1 mb-6 w-full">
-        <label htmlFor="nameInput" className="text-xs sm:text-sm">{labelText}</label>
-        <textarea
-          id="textarea"
-          placeholder={placeholder}
-          className="border border-gray-300 h-32 rounded-md shadow-sm w-full outline-green-500 text-sm p-2"
-          {...(register && register(registerLabel ?? "",
-            rules
-          ))}
-        ></textarea>
-        {errors && (errors[registerLabel] && <p className="text-xs font-ligh text-red-500">{errors[registerLabel]?.message as ReactNode}</p>)}
-      </div>
-    </>
-  )
-}
+  rules,
+}: PlainTextAreaProps): JSX.Element => (
+  <div className="flex flex-col gap-1 mb-6 w-full">
+    <label htmlFor="nameInput" className="text-xs sm:text-sm">
+      {labelText}
+    </label>
+    <textarea
+      id="textarea"
+      placeholder={placeholder}
+      defaultValue={defaultValue}
+      className="border border-gray-300 h-32 rounded-md shadow-sm w-full outline-green-500 text-sm p-2"
+      {...(register && register(registerLabel ?? "", rules))}
+    ></textarea>
+    {errors && errors[registerLabel] && (
+      <p className="text-xs font-ligh text-red-500">
+        {errors[registerLabel]?.message as ReactNode}
+      </p>
+    )}
+  </div>
+);

--- a/src/components/templetes/corporation/CorporateSIgnUp.tsx
+++ b/src/components/templetes/corporation/CorporateSIgnUp.tsx
@@ -26,7 +26,7 @@ export const CorporateSignUp = () => {
     authRepository.employeeSignUpWithEmail(email, password, sharedPassword).then(result => {
       if(result) {
       setIsOpen(true)
-      setModalMessage(result.success)
+      setModalMessage(result.message)
       setColor(result.success)
 
       setTimeout(() => {

--- a/src/components/templetes/user/GithubInfo.tsx
+++ b/src/components/templetes/user/GithubInfo.tsx
@@ -1,40 +1,74 @@
-import { UserState } from "@/global-states/atoms";
+import { UserState, UserStateType } from "@/global-states/atoms";
 import { UserRepository } from "@/modules/user/user.repository";
 import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 import { useRecoilState } from "recoil";
 import { SubmitButton } from "../../atoms/SubmitButton";
 import { PlainInput } from "../../atoms/PlainInput";
+import { SuccessOrFailureModal } from "@/components/organisms/SuccessOrFailureModal";
+import { useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
 
 export const GithubInfoPage = (): JSX.Element => {
-  const [userState, setUserState] = useRecoilState(UserState);
+  useAuth();
+  const [userState, setUserState] = useRecoilState<UserStateType>(UserState);
   const { register, handleSubmit } = useForm();
   const router = useRouter();
 
-  // const onSubmit = async (submitData: any) => {
-  //   setUserState({ ...userState, ...submitData });
-  //   //※デプロイまでには↓エラーはスローしないようにしたい
-  //   if (!userState?.uid) throw new Error("userState.uidがないです！");
-  //   await UserRepository.update(userState.uid, { ...userState, ...submitData });
-  //   router.push("/homeScreen");
-  // };
+  //プロフィール編集失敗/成功notice
+  const [isNoticeOpen, setIsNoticeOpen] = useState(false);
+  const [noticeMessage, setNoticeMessage] = useState("");
+  const [noticeColor, setNoticeColor] = useState<boolean>();
+  const closeNotice = () => setIsNoticeOpen(false);
+
+  const onSubmit = async (submitData: any) => {
+    await UserRepository.updateUserInfo({ ...userState, ...submitData }).then(
+      (result) => {
+        setUserState({ ...userState, ...submitData });
+
+        //notice表示
+        setIsNoticeOpen(true);
+        setNoticeMessage(result.message);
+        setNoticeColor(result.success);
+
+        setTimeout(
+          () => {
+            setIsNoticeOpen(false);
+            if (result.success) {
+              router.push("/homeScreen");
+            }
+          },
+          result.success ? 2000 : 4000
+        );
+      }
+    );
+  };
 
   return (
-    <div className="flex flex-col justify-center px-80 h-screen bg-red-50 text-lg">
+    <div className="flex flex-col justify-center px-80 h-screen text-lg">
       <form
-        // onSubmit={handleSubmit(onSubmit)}
+        onSubmit={handleSubmit(onSubmit)}
         className="container flex flex-col gap-12 max-w-500"
       >
         <PlainInput
-          labelText="GitHub アカウント名"
-          placeholder="https://github.com/<hoge> の<hoge>の部分"
+          labelText="GitHubアカウント (アカウントがなければ「完了」を押して飛ばしてください。)"
+          placeholder="(例) https://github.com/[username]"
+          defaultValue={userState?.githubAccount}
           register={register}
-          registerLabel="github"
+          registerLabel="githubAccount"
         />
         <div className="flex justify-center mt-24">
           <SubmitButton innerText="完了" />
         </div>
       </form>
+
+      {/* 成功/失敗notice */}
+      <SuccessOrFailureModal
+        isOpen={isNoticeOpen}
+        closeModal={closeNotice}
+        modalMessage={noticeMessage}
+        modalBgColor={noticeColor!}
+      />
     </div>
   );
 };

--- a/src/components/templetes/user/OtherThanTech.tsx
+++ b/src/components/templetes/user/OtherThanTech.tsx
@@ -82,6 +82,7 @@ export const OtherThanTechPage = (): JSX.Element => {
         />
         <PlainInput
           labelText="年齢"
+          inputType="number"
           placeholder="数字のみで年齢をご記入ください"
           defaultValue={userState?.age}
           register={register}

--- a/src/components/templetes/user/OtherThanTech.tsx
+++ b/src/components/templetes/user/OtherThanTech.tsx
@@ -1,4 +1,4 @@
-import { UserState } from "@/global-states/atoms";
+import { UserState, UserStateType } from "@/global-states/atoms";
 import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 import { useRecoilState } from "recoil";
@@ -6,9 +6,23 @@ import { SubmitButton } from "../../atoms/SubmitButton";
 import { PlainInput } from "../../atoms/PlainInput";
 import { GraduationYearRadio } from "../../atoms/GraduationYearRadio";
 import { PlainTextArea } from "@/components/atoms/PlainTextarea";
+import { useAuth } from "@/hooks/useAuth";
+import { UserRepository } from "@/modules/user/user.repository";
+import { useEffect, useState } from "react";
+import { SuccessOrFailureModal } from "@/components/organisms/SuccessOrFailureModal";
+import { Loading } from "../common/Loading";
 
 export const OtherThanTechPage = (): JSX.Element => {
-  const [userState, setUserState] = useRecoilState(UserState);
+  useAuth();
+  const [userState, setUserState] = useRecoilState<UserStateType>(UserState);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (userState) {
+      setIsLoading(false);
+    }
+  }, [userState?.firebaseUID]);
+
   const {
     register,
     handleSubmit,
@@ -17,10 +31,36 @@ export const OtherThanTechPage = (): JSX.Element => {
   } = useForm();
   const router = useRouter();
 
-  const onSubmit = (submitData: any) => {
-    setUserState({ ...userState, ...submitData });
-    router.push("/profiles/user/skill");
+  //プロフィール編集失敗/成功notice
+  const [isNoticeOpen, setIsNoticeOpen] = useState(false);
+  const [noticeMessage, setNoticeMessage] = useState("");
+  const [noticeColor, setNoticeColor] = useState<boolean>();
+  const closeNotice = () => setIsNoticeOpen(false);
+
+  const onSubmit = async (submitData: any) => {
+    await UserRepository.updateUserInfo({ ...userState, ...submitData }).then(
+      (result) => {
+        setUserState({ ...userState, ...submitData });
+
+        //notice表示
+        setIsNoticeOpen(true);
+        setNoticeMessage(result.message);
+        setNoticeColor(result.success);
+
+        setTimeout(
+          () => {
+            setIsNoticeOpen(false);
+            if (result.success) {
+              router.push("/profiles/user/skill");
+            }
+          },
+          result.success ? 1000 : 3000
+        );
+      }
+    );
   };
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="flex flex-col justify-center items-center h-full">
@@ -34,13 +74,16 @@ export const OtherThanTechPage = (): JSX.Element => {
         <PlainInput
           labelText="名前"
           placeholder="フルネームをご入力ください"
+          defaultValue={userState?.name}
           register={register}
           registerLabel="name"
           errors={errors}
+          rules={{ required: "必須項目です" }}
         />
         <PlainInput
           labelText="年齢"
           placeholder="数字のみで年齢をご記入ください"
+          defaultValue={userState?.age}
           register={register}
           registerLabel="age"
           errors={errors}
@@ -48,6 +91,7 @@ export const OtherThanTechPage = (): JSX.Element => {
         <PlainInput
           labelText="都道府県"
           placeholder="兵庫県"
+          defaultValue={userState?.prefecture}
           register={register}
           registerLabel="prefecture"
           errors={errors}
@@ -55,6 +99,7 @@ export const OtherThanTechPage = (): JSX.Element => {
         <PlainInput
           labelText="大学・専門"
           placeholder="〇〇大学"
+          defaultValue={userState?.university}
           register={register}
           registerLabel="university"
           errors={errors}
@@ -62,6 +107,7 @@ export const OtherThanTechPage = (): JSX.Element => {
         <PlainInput
           labelText="学部・学科"
           placeholder="〇〇学部/△△学科"
+          defaultValue={userState?.undergraduate}
           register={register}
           registerLabel="undergraduate"
           errors={errors}
@@ -70,6 +116,7 @@ export const OtherThanTechPage = (): JSX.Element => {
           registerLabel="selfPublicity"
           labelText="自己紹介"
           placeholder="自己PRなどご記入ください"
+          defaultValue={userState?.selfPublicity}
           register={register}
           errors={errors}
           rules={{ required: "必須項目です" }}
@@ -79,28 +126,28 @@ export const OtherThanTechPage = (): JSX.Element => {
           registerLabel="careerVision"
           labelText="キャリアビジョン"
           placeholder="自身のキャリアについてご記入ください"
+          defaultValue={userState?.careerVision}
           register={register}
           errors={errors}
           rules={{ required: "必須項目です" }}
         />
-        <GraduationYearRadio control={control} />
+        <GraduationYearRadio
+          control={control}
+          defaultValue={userState?.graduateYear}
+        />
 
         <div className="flex justify-center mt-4">
           <SubmitButton innerText="次へ" />
         </div>
       </form>
+
+      {/* 成功/失敗notice */}
+      <SuccessOrFailureModal
+        isOpen={isNoticeOpen}
+        closeModal={closeNotice}
+        modalMessage={noticeMessage}
+        modalBgColor={noticeColor!}
+      />
     </div>
   );
 };
-
-// id: string;
-// name: string;
-// email: string;
-// imageUrl: string;
-// age: number;
-// prefecture: string;
-// university: string;
-// undergraduate: string;
-// selfPublicity: string;
-// careerVision: string;
-// programingSkills: Prisma.JsonValue;

--- a/src/components/templetes/user/SignIn.tsx
+++ b/src/components/templetes/user/SignIn.tsx
@@ -6,6 +6,7 @@ import { EmailAndPasswordForm } from "@/components/organisms/EmailAndPasswordFor
 import { useState } from "react";
 import { SuccessOrFailureModal } from "@/components/organisms/SuccessOrFailureModal";
 import { useAuth } from "@/hooks/useAuth";
+import { ConfirmModal } from "@/types/confirmModal";
 
 type FormData = {
   email: string;
@@ -24,46 +25,45 @@ export const SignIn: React.FC = (): JSX.Element => {
 
   const onSubmit = ({ email, password }: FormData) => {
     authRepository.signInWithEmail(email, password).then((result) => {
-      if (result) {
-        setIsOpen(true);
-        setModalMessage(result.message);
-        setColor(result.success);
+      setIsOpen(true);
+      setModalMessage(result.message);
+      setColor(result.success);
 
-        setTimeout(
-          () => {
-            setIsOpen(false);
-            if (result.success) {
-              router.push("/homeScreen");
-            }
-          },
-          result.success ? 2000 : 4000
-        );
-      }
+      setTimeout(
+        () => {
+          setIsOpen(false);
+          if (result.success && !result.data.name) {
+            router.push("/profiles/user/otherThanTech");
+            return;
+          }
+          if (result.success) {
+            router.push("/homeScreen");
+          }
+        },
+        result.success ? 2000 : 4000
+      );
     });
   };
 
-  const onClickGoogleOrGithub = (
-    promise: Promise<{
-      success: boolean;
-      message: string;
-    }>
-  ) => {
-    promise.then((result) => {
-      if (result) {
-        setIsOpen(true);
-        setModalMessage(result.message);
-        setColor(result.success);
+  const onClickGoogleOrGithub = (promise: Promise<ConfirmModal>) => {
+    promise.then((result: ConfirmModal) => {
+      setIsOpen(true);
+      setModalMessage(result.message);
+      setColor(result.success);
 
-        setTimeout(
-          () => {
-            setIsOpen(false);
-            if (result.success) {
-              router.push("/homeScreen");
-            }
-          },
-          result.success ? 2000 : 4000
-        );
-      }
+      setTimeout(
+        () => {
+          setIsOpen(false);
+          if (result.success && result.isCreated) {
+            router.push("/profiles/user/otherThanTech");
+            return;
+          }
+          if (result.success) {
+            router.push("/homeScreen");
+          }
+        },
+        result.success ? 2000 : 4000
+      );
     });
   };
 

--- a/src/components/templetes/user/SignUp.tsx
+++ b/src/components/templetes/user/SignUp.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { AuthButton } from "../../atoms/AuthButton";
+import { ConfirmModal } from "@/types/confirmModal";
 
 type FormData = {
   email: string;
@@ -33,7 +34,7 @@ export const SignUp = () => {
             () => {
               setIsOpen(false);
               if (result.success) {
-                router.push("/signIn");
+                router.push("/profiles/user/otherThanTech");
               }
             },
             result.success ? 2000 : 4000
@@ -42,12 +43,7 @@ export const SignUp = () => {
       });
   };
 
-  const onClickGoogleOrGithub = (
-    promise: Promise<{
-      success: boolean;
-      message: string;
-    }>
-  ) => {
+  const onClickGoogleOrGithub = (promise: Promise<ConfirmModal>) => {
     promise.then((result) => {
       if (result) {
         setIsOpen(true);
@@ -57,8 +53,12 @@ export const SignUp = () => {
         setTimeout(
           () => {
             setIsOpen(false);
+            if (result.success && result.isCreated) {
+              router.push("/profiles/user/otherThanTech");
+              return;
+            }
             if (result.success) {
-              router.push("/profiles/otherThanTech");
+              router.push("/homeScreen");
             }
           },
           result.success ? 2000 : 4000
@@ -101,7 +101,7 @@ export const SignUp = () => {
 
       <div className="flex justify-center">
         <p className="text-sm sm:text-base">アカウンントをお持ちの方　</p>
-        <Link href="/signUp" className="font-bold">
+        <Link href="/signIn" className="font-bold">
           ログイン
         </Link>
       </div>

--- a/src/components/templetes/user/UserProfile.tsx
+++ b/src/components/templetes/user/UserProfile.tsx
@@ -22,12 +22,19 @@ import { PiSignOutBold } from "react-icons/pi";
 import { authRepository } from "@/modules/auth/auth.repository";
 import { ConfirmModal } from "@/components/organisms/ConfirmModal";
 import { PersonIcon } from "@/components/atoms/PersonIcon";
+import Image from "next/image";
 
 export const UserProfile = (): JSX.Element => {
   const router = useRouter();
   const { id: userId } = router.query;
 
-  const { register, handleSubmit, control, reset } = useForm();
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = useForm();
 
   const [isConfirmOpen, setIsConfirmOpen] = useState<boolean>(false);
 
@@ -73,6 +80,9 @@ export const UserProfile = (): JSX.Element => {
 
   const onSignOut = async () => {
     await authRepository.logOut().then((result) => {
+      setMyselfState(null);
+      localStorage.clear();
+
       //notice表示
       setIsSignOutNoticeOpen(true);
       setSignOutNoticeMessage(result.message);
@@ -176,6 +186,8 @@ export const UserProfile = (): JSX.Element => {
             onBlur={handleSubmit(onEditSubmit)}
             register={register}
             registerLabel="name"
+            rules={{ required: "必須項目です" }}
+            errors={errors}
             defaultValue={profileUser.name}
             disabled={!isMyself}
             labelFont="text-base"
@@ -215,21 +227,52 @@ export const UserProfile = (): JSX.Element => {
         >
           <GraduationYearRadio
             control={control}
+            defaultValue={profileUser.graduateYear}
             defaultChipColor={"bg-gray-100"}
           />
         </EditProfileModal>
         {/* GtHubアカウント */}
-        <PlainInput
-          labelText="GitHubアカウント名"
-          placeholder="https://github.com/<hoge> の<hoge>の部分"
-          onBlur={handleSubmit(onEditSubmit)}
-          register={register}
-          registerLabel="githubAccount"
-          defaultValue={profileUser.githubAccount}
-          disabled={!isMyself}
-          labelFont="text-base"
-          inputFont="text-sm sm:text-base"
-        />
+        {isMyself ? (
+          <PlainInput
+            labelText="GitHubアカウント"
+            placeholder="(例) https://github.com/[username]"
+            onBlur={handleSubmit(onEditSubmit)}
+            register={register}
+            registerLabel="githubAccount"
+            defaultValue={profileUser.githubAccount}
+            disabled={!isMyself}
+            labelFont="text-base"
+            inputFont="text-sm sm:text-base"
+          />
+        ) : (
+          <div className="flex flex-col gap-4 mb-4 w-full">
+            <label htmlFor="nameInput" className="">
+              GitHubアカウント
+            </label>
+            {profileUser.githubAccount ? (
+              <Link
+                href={profileUser.githubAccount ?? ""}
+                target="_blank"
+                className="ml-10 w-12 h-12"
+              >
+                <Image
+                  src="/github-mark.png"
+                  alt="GitHubロゴ"
+                  width={240}
+                  height={240}
+                />
+              </Link>
+            ) : (
+              <Image
+                src="/github-mark.png"
+                alt="GitHubロゴ"
+                width={240}
+                height={240}
+                className="ml-10 w-12 h-12 opacity-10"
+              />
+            )}
+          </div>
+        )}
         {/* プログラミングスキル */}
         <FormField
           labelText="プログラミングスキル"

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -9,6 +9,8 @@ export const FAIL_TO_SIGN_UP = "新規登録に失敗しました。";
 
 export const MAIL_USED_IN_PROVIDER_EXISTS =
   "選択した認証プロバイダで使用されているメールアドレスが、本サービスですでに登録済みである可能性があります。";
+export const FAIL_TO_GET_GITHUB_USER =
+  "GitHubのユーザー情報を正しく取得できませんでした。";
 
 export const FAIL_TO_PUSH_LIKE = "いいねを押すことに失敗しました。";
 export const FAIL_TO_DELETE_LIKE = "いいねを取り消すことに失敗しました。";

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,17 +14,22 @@ export const useAuth = (): UserStateType => {
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (authUser) => {
-      if (authUser) {
-        const token = await authUser.getIdToken();
-        setAuthToken(token);
-        
-        const user = await UserRepository.findUserByFirebaseUID();
-        if (user) {
-          setUser(user);
-        }
-      } else {
+      //操作者がfirebase上でログインしている状態でなければ、サインインページにリダイレクト
+      if (!authUser) {
         router.push("/signIn");
+        return;
       }
+
+      const token = await authUser.getIdToken();
+      setAuthToken(token);
+
+      const user = await UserRepository.findUserByFirebaseUID();
+      //firebase上でログインしている操作者がDBのuserレコード上では見つからなかった場合も、サインインページにリダイレクト
+      if (!user) {
+        router.push("/signIn");
+        return;
+      }
+      setUser(user);
     });
     return () => unsub();
   }, []);

--- a/src/libs/github.ts
+++ b/src/libs/github.ts
@@ -1,0 +1,29 @@
+import { FAIL_TO_GET_GITHUB_USER } from "@/constants/constants";
+import axios from "axios";
+
+export const GithubUtils = {
+  async getAuthenticatedUser(accessToken: string | undefined) {
+    try {
+      const user = (
+        await axios.get("https://api.github.com/user", {
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${accessToken}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        })
+      ).data;
+
+      return user;
+    } catch (error: unknown) {
+      const isTypeSafeError = error instanceof Error;
+
+      return {
+        success: false,
+        message: `${FAIL_TO_GET_GITHUB_USER}\n${
+          isTypeSafeError ? error.message : ""
+        }`,
+      };
+    }
+  },
+};

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -5,6 +5,7 @@ import {
   FAIL_TO_UPDATE_USER,
   SUCCESS_IN_UPDATE_USER,
 } from "@/constants/constants";
+import { ConfirmModal } from "@/types/confirmModal";
 
 export const UserRepository = {
   //全件取得
@@ -55,7 +56,7 @@ export const UserRepository = {
   //更新
   async updateUserInfo(
     submitData: any
-  ): Promise<{ data: User | null; success: boolean; message: string }> {
+  ): Promise<ConfirmModal & { data: User | null }> {
     try {
       const user = (
         await axiosInstance.put("/user/update-by-firebase-uid", submitData, {

--- a/src/types/confirmModal.ts
+++ b/src/types/confirmModal.ts
@@ -1,4 +1,6 @@
 export type ConfirmModal = {
   message: string;
   success?: boolean;
-}
+  data?: any;
+  isCreated?: boolean;
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,9 +6,10 @@ export type User = {
   age?: string;
   prefecture?: string;
   university?: string;
+  undergraduate?: string;
   graduateYear?: string;
-  self_publicity?: string;
-  career_vision?: string;
+  selfPublicity?: string;
+  careerVision?: string;
   position?: string;
   development_experience?: boolean;
   internship_experience?: boolean;


### PR DESCRIPTION
## 概要
メールアドレス / google / githubなどどの認証媒体でも、登録時 (初回ログイン時) はユーザー情報登録フォームに遷移

## 確認
github初回サインイン
[画面収録 2023-07-09 18.54.25.zip](https://github.com/nagayamajun/unite-replace-front/files/11994887/2023-07-09.18.54.25.zip)

github２回目以降サインイン
[画面収録 2023-07-09 18.56.12.zip](https://github.com/nagayamajun/unite-replace-front/files/11994892/2023-07-09.18.56.12.zip)

メールアドレス/パスワード 初回登録
[画面収録 2023-07-09 17.59.39.zip](https://github.com/nagayamajun/unite-replace-front/files/11994897/2023-07-09.17.59.39.zip)

メールアドレス/パスワード ユーザー名設定してあればhomescreenに飛ぶが、ユーザー名なかったら入力フォームに遷移
[画面収録 2023-07-09 18.20.46.zip](https://github.com/nagayamajun/unite-replace-front/files/11994900/2023-07-09.18.20.46.zip)
