### PR TITLE
[FE]user側の画面のUI修正

### DIFF
--- a/src/components/layouts/Layout/UserLayout.tsx
+++ b/src/components/layouts/Layout/UserLayout.tsx
@@ -33,7 +33,7 @@ export const UserLayout = ({ children }: Props) => {
 
       <div className="hidden sm:flex sm:flex-row">
         <SideBar />
-        <div className="flex-grow bg-gray-100 flex items-center justify-center">
+        <div className="flex flex-grow w-auto bg-gray-50 ">
           {children}
         </div>
       </div>

--- a/src/components/layouts/Sidebar/UserSidebar.tsx
+++ b/src/components/layouts/Sidebar/UserSidebar.tsx
@@ -14,7 +14,7 @@ export const SideBar = (): JSX.Element => {
 
   const menuLinks = [
     { href: `/homeScreen`, label: "募集一覧", icon: <CiViewList /> },
-    { href: `/addRecruit`, label: "募集を作成", icon: <IoIosCreate /> },
+    { href: `/recruit/addRecruit`, label: "募集を作成", icon: <IoIosCreate /> },
     {
       href: `/profiles/user/${userStateVal?.id}`,
       label: "マイページへ",

--- a/src/components/molecules/Button/SubmitButton.tsx
+++ b/src/components/molecules/Button/SubmitButton.tsx
@@ -1,10 +1,11 @@
 type SubmitButtonProps = {
   innerText: string;
+  disabled?: boolean;
 };
 
-export const SubmitButton = ({ innerText }: SubmitButtonProps): JSX.Element => {
+export const SubmitButton = ({ innerText, disabled }: SubmitButtonProps): JSX.Element => {
   return (
-    <button type="submit" className="bg-green-500 text-white rounded-md p-2 my-3 w-full">
+    <button type="submit" disabled={disabled} className="bg-green-500 text-white rounded-md p-2 my-3 w-full">
       {innerText}
     </button>
   );

--- a/src/components/organisms/Loading/Loading.tsx
+++ b/src/components/organisms/Loading/Loading.tsx
@@ -1,6 +1,11 @@
-export const Loading: React.FC = ():JSX.Element => {
+type Props = {
+  message?: string
+}
+
+export const Loading = ({ message}: Props):JSX.Element => {
   return (
-    <div className="flex justify-center h-screen w-screen items-center">
+    <div className="flex flex-col justify-center h-screen w-full items-center">
+      <p className="font-semibold">{message}</p>
       <img src="/load.gif" className=" w-16 h-16"/>
     </div>
   )

--- a/src/features/product/components/organisms/List/MyProductList.tsx
+++ b/src/features/product/components/organisms/List/MyProductList.tsx
@@ -11,10 +11,10 @@ export const MyProductList = (): JSX.Element => {
   if (user === undefined && myProducts === undefined) <Loading />
 
   return (
-    <div className="flex flex-col w-80 sm:w-base md:w-sm mt-10 sm:mt-20 p-5 bg-gray-100 sm:bg-white rounded-lg shadow-md">
+    <div className="flex flex-col w-80 sm:w-sm md:w-md mt-10 sm:mt-20 p-5 sm:bg-white rounded-lg shadow-md">
       <h1 className="text-center mb-5 font-bold text-lg">自分の作成した作品一覧</h1>
       {myProducts?.length === 0 ? (
-        <p className="text-center font-bold text-red-400">There are no my recruits.</p>
+        <p className="text-center font-bold text-red-400">まだ作成していません。</p>
       ) : (
         myProducts?.map((myProduct, index) => {
           //自分の作成したコメントがあるかをチェックする

--- a/src/features/product/components/organisms/List/RelatedProductList.tsx
+++ b/src/features/product/components/organisms/List/RelatedProductList.tsx
@@ -12,10 +12,10 @@ export const RelatedProductList = (): JSX.Element => {
   if (user === undefined && relatedProducts === undefined) <Loading />
 
   return (
-    <div className="w-80 sm:w-sm mt-10 sm:mt-20 p-5 bg-gray-100 sm:bg-white rounded-lg shadow-md">
+    <div className="w-80 sm:w-sm md:w-md mt-10 sm:mt-20 p-5 bg-gray-100 sm:bg-white rounded-lg shadow-md">
       <h1 className="text-center mb-5 font-bold text-lg">参加した作品一覧</h1>
       {relatedProducts?.length === 0 ? (
-        <p className="text-center font-bold text-red-400">There are no my recruits.</p>
+        <p className="text-center font-bold text-red-400">まだ作成されていません。</p>
       ) : (
         relatedProducts?.map((relatedProduct, index) => {
           //自分の作成したコメントがあるかをチェックする

--- a/src/features/product/components/templates/EditProduct.tsx
+++ b/src/features/product/components/templates/EditProduct.tsx
@@ -56,7 +56,7 @@ export const EditProduct = ({ path }: Props) => {
   if (product === undefined || isLiked === undefined) return <Loading /> 
 
   return (
-    <div className="flex flex-col w-full h-full min-h-screen justify-center items-center text-gray-600 bg-gray-100">
+    <div className="flex flex-col w-full h-full min-h-screen justify-center items-center text-gray-600 ">
       <div className="flex flex-col rounded-lg items-center w-4/5 sm:w-base md:w-sm gap-14 mb-10 bg-white">
         <div className="flex justify-center items-center w-4/5 mt-10">
           <video src={product?.url} controls className="w-full h-60"></video>

--- a/src/features/product/components/templates/MyProductAndRelatedProduct.tsx
+++ b/src/features/product/components/templates/MyProductAndRelatedProduct.tsx
@@ -21,7 +21,7 @@ export const MyProductAndRelatedProduct = () => {
   }, [])
 
   return (
-    <div className="flex flex-col items-center justify-start h-screen space-y-10">
+    <div className="flex flex-col items-center w-full h-screen space-y-10">
       {/* 自分で作成したProduct */}
       <MyProductList />
       {/* 関連したProduct */}

--- a/src/features/product/components/templates/UploadProduct.tsx
+++ b/src/features/product/components/templates/UploadProduct.tsx
@@ -6,6 +6,7 @@ import { productRepository, submitProductDate } from "@/features/product/modules
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useForm } from "react-hook-form"
+import { Loading } from "@/components/organisms/Loading/Loading";
 
 export const UploadProduct = () => {
   const { register, handleSubmit } = useForm();
@@ -18,7 +19,10 @@ export const UploadProduct = () => {
   const [color, setColor] = useState<boolean>();
   const closeModal = () => setIsOpen(false);
 
+  const [isLoading, setIsLoading] = useState(false);
+
   const onSubmit = async (data: any) => {
+    setIsLoading(true)
     const file = data.file[0];
     const fileExtension = file.name.split(".").pop()?.toLowerCase();
 
@@ -37,6 +41,7 @@ export const UploadProduct = () => {
     await productRepository.createProduct(submitDate)
       .then(result => {
         if(result) {
+          setIsLoading(false)
           setIsOpen(true)
           setModalMessage(result.message)
           setColor(result.success);
@@ -45,7 +50,7 @@ export const UploadProduct = () => {
             setIsOpen(false)
             if (!result.success) return router.reload();
             router.push("/homeScreen")
-          }, 2000)
+          }, 4000)
         }
       })
   }
@@ -58,6 +63,8 @@ export const UploadProduct = () => {
 
     return allowedExtensions.includes(extension);
   };
+
+  // if(isLoading) return <Loading message={'アップロード中です。このままお待ちください'}/>
 
   return (
     <div className="flex flex-col items-center justify-center w-full h-screen">
@@ -83,7 +90,8 @@ export const UploadProduct = () => {
           registerLabel="detail"
         />
         <SubmitButton
-          innerText="アップロードする"
+          innerText={isLoading ? 'アップロード中です' : 'アップロードする'}
+          disabled={isLoading}
         />
       </form>
 

--- a/src/features/recruit/components/organisms/Card/RecruitCard.tsx
+++ b/src/features/recruit/components/organisms/Card/RecruitCard.tsx
@@ -1,3 +1,5 @@
+import { PersonIcon } from "@/components/molecules/Icon/PersonIcon";
+import { User } from "@/features/user/types/user";
 import Link from "next/link";
 
 type RecruitCardProps = {
@@ -7,6 +9,7 @@ type RecruitCardProps = {
   headline: string;
   programingSkills: string[];
   hackthonName?: string;
+  recruiter?: User
 };
 
 export const RecruitCard = ({
@@ -15,41 +18,52 @@ export const RecruitCard = ({
   headline,
   programingSkills,
   hackthonName,
+  recruiter
 }: RecruitCardProps): JSX.Element => (
   <div
-    className={`group relative mb-2 h-96 border overflow-hidden rounded-xl sm:mb-3 shadow-md min-w-[400px]`}
+    className={`group relative px-6 py-8 mb-2 sm:mb-3 h-auto bg-white border overflow-hidden rounded-xl shadow-md min-w-[400px] max-w-[560px]  flex flex-col justify-start gap-4`}
   >
-    <div className="flex justify-center items-center h-2/5 bg-gradient-to-r from-recruite-card-bg to-pink-200">
-      <p className="text-2xl sm:text-4xl font-bold text-white">
-        {hackthonName ? hackthonName : headline}
+    {/* ハッカソン名 */}
+    <div className="flex flex-col">
+      <p className="text-sm">ハッカソン名(チーム名)</p>
+      <p className="text-xl sm:text-2xl font-semibold text-black">
+          {hackthonName ? hackthonName : headline}
       </p>
     </div>
-    <div className="flex col">
-      {programingSkills?.map((skill, index) => (
-        <div key={index} className="flex flex-wrap justify-start line-clamp-1">
-          <span className="text-gray-500 inline-flex items-center gap-1.5 py-1 px-2  mx-1 my-3  text-xs rounded-full border-2 border-gray-400 ">
-            {skill}
-          </span>
-        </div>
-      ))}
-    </div>
-    <div className="flex justify-center items-center h-1/3">
+    {/* ひとこと */}
+    <div className="flex flex-col ">
+      <p className="text-sm">ひとこと</p>
       <div className="flex flex-col">
-        <h3 className="font-zen font-regular text-lg sm:text-2xl mx-3 sm:mx-10 line-clamp-1 text-gray-500">
+        <h3 className="text-lg sm:text-xl line-clamp-1 ">
           {headline}
         </h3>
       </div>
     </div>
-    <div className="flex justify-between mb-3 ">
-      <div className="w-2/3 flex col items-center">
-        <p className="text-sm pl-8">
-          {new Date(createdAt).toISOString().slice(0, 10)}
-        </p>
+    {/* 募集スキル */}
+    <div className="flex flex-col">
+      <p className="text-sm">募集スキル</p>
+      <div className="flex col">
+        {programingSkills?.map((skill, index) => (
+          <div key={index} className="flex flex-wrap justify-start line-clamp-1">
+            <span className="text-gray-500 inline-flex items-center gap-1.5 py-1 px-2  mx-1 my-3  text-sm rounded-full border-2 border-gray-500 ">
+              {skill}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+
+    <div className="flex justify-between">
+      <div className=" flex col items-center">
+        <p className="text-sm mr-3 mb-2 sm:mb-0 sm:text-base">募集主: {recruiter?.name}</p>
+        <PersonIcon 
+          originalIconImageSrc={recruiter?.imageUrl}
+        />
       </div>
       <div className="w-1/3 flex flex-col justify-center items-center">
         <Link
           href={`/recruit/${id}/recruitDetail`}
-          className=" text-green-800  rounded-lg focus:outline-none focus:border-transparent text-center bg-transparent text-sm sm:text-lg hover:bg-pink-300 hover:text-white p-3"
+          className=" text-green-800  rounded-lg focus:outline-none focus:border-transparent text-center bg-transparent text-sm sm:text-lg p-3"
         >
           詳細を見る
         </Link>

--- a/src/features/recruit/components/organisms/Card/RecruitCard.tsx
+++ b/src/features/recruit/components/organisms/Card/RecruitCard.tsx
@@ -21,7 +21,7 @@ export const RecruitCard = ({
   recruiter
 }: RecruitCardProps): JSX.Element => (
   <div
-    className={`group relative px-6 py-8 mb-2 sm:mb-3 h-auto bg-white border overflow-hidden rounded-xl shadow-md min-w-[400px] max-w-[560px]  flex flex-col justify-start gap-4`}
+    className={`group relative px-6 py-8 mb-2 sm:mb-3 h-auto bg-white border overflow-hidden rounded-xl shadow-md sm:min-w-[400px] max-w-[560px]  flex flex-col justify-start gap-4`}
   >
     {/* ハッカソン名 */}
     <div className="flex flex-col">

--- a/src/features/recruit/components/organisms/List/MyRecruitsList.tsx
+++ b/src/features/recruit/components/organisms/List/MyRecruitsList.tsx
@@ -8,10 +8,10 @@ export const MyRecruitsList = (): JSX.Element => {
 
   if (myRecruits === undefined) <Loading />
   return (
-    <div className="w-80 sm:w-sm mt-10 sm:mt-20 p-5 bg-gray-100 sm:bg-white rounded-lg shadow-md">
+    <div className="w-80 sm:w-sm md:w-md mt-10 sm:mt-20 p-5 bg-gray-100 sm:bg-white rounded-lg shadow-md">
       <h1 className="text-center mb-5 font-bold text-lg">自分の作成した募集一覧</h1>
       {myRecruits?.length === 0 ? (
-        <p className="text-center font-bold text-red-400">There are no my recruits.</p>
+        <p className="text-center font-bold text-red-400">まだ作成していません。</p>
       ) : (
         myRecruits?.map((myRecruit, index) => {
           const hasApprovedApplicants = myRecruit.userRecruitParticipant?.some(participant => participant.isApproved === false);

--- a/src/features/recruit/components/organisms/List/RecruitList.tsx
+++ b/src/features/recruit/components/organisms/List/RecruitList.tsx
@@ -2,16 +2,35 @@ import { UserState } from "@/stores/atoms";
 import {  useRecoilValue } from "recoil";
 import { RecruitCard } from "../Card/RecruitCard";
 import { recruitAtomState } from "@/features/recruit/stores/recruitAtom";
-import { filteredRecruitAtomState } from "@/features/recruit/stores/filteredRecruits";
 import Link from "next/link";
 import { User } from "@/features/user/types/user";
+import { useRouter } from "next/router";
+import { ProgramingSkill } from "@/features/user/types/programingSkill";
 
 
 export const RecruitList = (): JSX.Element => {
+  const router = useRouter();
   const user = useRecoilValue(UserState);
 
   const recruits = useRecoilValue(recruitAtomState);
-  const filteredRecruits = useRecoilValue(filteredRecruitAtomState);
+
+  const filteredRecruits = recruits.filter((recruit) => {
+    const name = router.query.name as string;
+    const skills = router.query.skills as ProgramingSkill[];
+
+    if (name && skills?.length > 0) {
+      return (
+        recruit.hackthonName === name &&
+        recruit.programingSkills.some((skill) => skills.includes(skill))
+      );
+    } else if (name) {
+      return recruit.hackthonName === name;
+    } else if (skills?.length) {
+      return recruit.programingSkills.some((skill) => skills.includes(skill));
+    }
+    return true;
+  });
+
 
   type RecruitCardProps = {
     id: string;
@@ -23,11 +42,11 @@ export const RecruitList = (): JSX.Element => {
   };
 
   return (
-    <div className="bg-gray-100 pt-10 min-h-screen">
-      <div className="grid mx-12 sm:mx-20 gap-x-20 gap-y-8 sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2">
-          {filteredRecruits.length == 0 && <p className="font-bold">条件に一致する募集はありません</p>}
-          { filteredRecruits?.map((recruit: RecruitCardProps) => {
-            if (user?.id !== recruit?.recruiter?.id) {
+    <div className="bg-gray-50 pt-10 min-h-screen">
+      <div className="grid mx-12 lg:mx-20 gap-x-14 gap-y-8 sm:grid-cols-1 lg:grid-cols-2 ">
+        {filteredRecruits      
+          .map((recruit: RecruitCardProps) => {
+            // if (user?.id !== recruit?.recruiter?.id) {
               return (
                 <RecruitCard
                   key={recruit.id}
@@ -36,10 +55,13 @@ export const RecruitList = (): JSX.Element => {
                   headline={recruit.headline}
                   programingSkills={recruit.programingSkills}
                   hackthonName={recruit.hackthonName}
+                  recruiter={recruit.recruiter!}
                 />
               );
-            }
-          })}
+            // }
+          })
+        }
+        {filteredRecruits.length === 0 && <p className="font-bold">条件に一致する募集はありません</p>}
       </div>
 
       <Link href={"/recruit/addRecruit"} className="text-white text-4xl font-bold fixed bottom-0 right-0 mr-10 mb-10 bg-green-400 h-14 w-14 sm:w-20 sm:h-20 rounded-full flex col items-center justify-center">

--- a/src/features/recruit/components/organisms/List/RecruitList.tsx
+++ b/src/features/recruit/components/organisms/List/RecruitList.tsx
@@ -20,11 +20,11 @@ export const RecruitList = (): JSX.Element => {
 
     if (name && skills?.length > 0) {
       return (
-        recruit.hackthonName === name &&
+        recruit.hackthonName?.includes(name) &&
         recruit.programingSkills.some((skill) => skills.includes(skill))
       );
     } else if (name) {
-      return recruit.hackthonName === name;
+      return recruit.hackthonName?.includes(name);
     } else if (skills?.length) {
       return recruit.programingSkills.some((skill) => skills.includes(skill));
     }
@@ -46,7 +46,7 @@ export const RecruitList = (): JSX.Element => {
       <div className="grid mx-12 lg:mx-20 gap-x-14 gap-y-8 sm:grid-cols-1 lg:grid-cols-2 ">
         {filteredRecruits      
           .map((recruit: RecruitCardProps) => {
-            // if (user?.id !== recruit?.recruiter?.id) {
+            if (user?.id !== recruit?.recruiter?.id) {
               return (
                 <RecruitCard
                   key={recruit.id}
@@ -58,7 +58,7 @@ export const RecruitList = (): JSX.Element => {
                   recruiter={recruit.recruiter!}
                 />
               );
-            // }
+            }
           })
         }
         {filteredRecruits.length === 0 && <p className="font-bold">条件に一致する募集はありません</p>}

--- a/src/features/recruit/components/organisms/List/RecruitList.tsx
+++ b/src/features/recruit/components/organisms/List/RecruitList.tsx
@@ -17,18 +17,20 @@ export const RecruitList = (): JSX.Element => {
   const filteredRecruits = recruits.filter((recruit) => {
     const name = router.query.name as string;
     const skills = router.query.skills as ProgramingSkill[];
-
-    if (name && skills?.length > 0) {
-      return (
-        recruit.hackthonName?.includes(name) &&
-        recruit.programingSkills.some((skill) => skills.includes(skill))
-      );
-    } else if (name) {
-      return recruit.hackthonName?.includes(name);
-    } else if (skills?.length) {
-      return recruit.programingSkills.some((skill) => skills.includes(skill));
+  
+    switch (true) {
+      case !!name && skills?.length > 0:
+        return (
+          recruit.hackthonName?.includes(name) &&
+          recruit.programingSkills.some((skill) => skills.includes(skill))
+        );
+      case !!name:
+        return recruit.hackthonName?.includes(name);
+      case skills?.length > 0:
+        return recruit.programingSkills.some((skill) => skills.includes(skill));
+      default:
+        return true;
     }
-    return true;
   });
 
 

--- a/src/features/recruit/components/organisms/List/RelatedRecruitsList.tsx
+++ b/src/features/recruit/components/organisms/List/RelatedRecruitsList.tsx
@@ -7,10 +7,10 @@ export const RelatedRecruitsList = () => {
   if (relatedRecruits === undefined) <Loading />
 
   return (
-    <div className="w-80 sm:w-sm mt-10 sm:mt-20 p-5 bg-gray-100 sm:bg-white rounded-lg shadow-md">
+    <div className="w-80 sm:w-sm md:w-md mt-10 sm:mt-20 p-5 sm:bg-white rounded-lg shadow-md">
       <h1 className="text-center mb-5 font-bold text-lg">参加する/参加した募集一覧</h1>
       {relatedRecruits?.length === 0? (
-        <p className="text-center font-bold text-red-400">There are no related recruits.</p>
+        <p className="text-center font-bold text-red-400">まだ作成していません。</p>
       ) : (
         relatedRecruits?.map((relatedRecruit, index) => {
           return (

--- a/src/features/recruit/components/organisms/Search/NarrowSerch.tsx
+++ b/src/features/recruit/components/organisms/Search/NarrowSerch.tsx
@@ -25,31 +25,36 @@ export const NarrowSearch = () => {
 
   //条件でフィルターをかける関数
   const filterRecruit = (name?: string, skills?: ProgramingSkill[]) => {
-      if(name && skills?.length! > 0) {
+    switch (true) {
+      case name && skills?.length! > 0:
         router.push({
           pathname: '/homeScreen',
           query: {
             name: name,
-            skills:skills
-          }
-        })
-      } else if(name) {
+            skills: skills,
+          },
+        });
+        break;
+      case !!name:
         router.push({
           pathname: '/homeScreen',
           query: {
             name: name,
-          }
-        })
-      } else if(skills?.length! > 0) {
+          },
+        });
+        break;
+      case skills?.length! > 0:
         router.push({
           pathname: '/homeScreen',
           query: {
-            skills:skills
-          }
-        })
-      } else {
-        router.push('/homeScreen')
-      }
+            skills: skills,
+          },
+        });
+        break;
+      default:
+        router.push('/homeScreen');
+        break;
+    }
   };
 
   return (

--- a/src/features/recruit/components/organisms/Search/NarrowSerch.tsx
+++ b/src/features/recruit/components/organisms/Search/NarrowSerch.tsx
@@ -1,12 +1,11 @@
-import { filteredRecruitAtomState } from "@/features/recruit/stores/filteredRecruits";
 import { recruitAtomState } from "@/features/recruit/stores/recruitAtom";
 import { ProgramingSkill } from "@/features/user/types/programingSkill";
-import { Recruit } from "@/features/recruit/types/recruit";
 import { useForm } from "react-hook-form"
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue } from "recoil";
 import { PlainInput } from "../../../../../components/molecules/Input/PlainInput";
 import { SkillSelect } from "../../../../user/components/molecules/Select/SkillSelect";
 import { SubmitButton } from "../../../../../components/molecules/Button/SubmitButton";
+import { useRouter } from "next/router";
 
 type FiltteringData = {
   hackthonName?: string;
@@ -15,32 +14,47 @@ type FiltteringData = {
 
 export const NarrowSearch = () => {
 
+
+  const router = useRouter();
   const { handleSubmit, register, formState: {errors}, control } = useForm();
   const recruits = useRecoilValue(recruitAtomState);
-  const [filteredRecruits, setFilteredRecruits] = useRecoilState(filteredRecruitAtomState);
-
+  
   const onSubmit = ({hackthonName, programingSkills}: FiltteringData) => {
     filterRecruit(hackthonName, programingSkills)
   }
 
   //条件でフィルターをかける関数
   const filterRecruit = (name?: string, skills?: ProgramingSkill[]) => {
-    let alterRecruitList = recruits.filter((recruit) => {
       if(name && skills?.length! > 0) {
-        return recruit.hackthonName?.includes(name) && recruit.programingSkills?.some((skill) => skills?.includes(skill));
-      } else if(name || skills?.length! > 0) {
-        return (name && recruit.hackthonName?.includes(name)) || (skills && recruit.programingSkills?.some((skill) => skills.includes(skill)));
+        router.push({
+          pathname: '/homeScreen',
+          query: {
+            name: name,
+            skills:skills
+          }
+        })
+      } else if(name) {
+        router.push({
+          pathname: '/homeScreen',
+          query: {
+            name: name,
+          }
+        })
+      } else if(skills?.length! > 0) {
+        router.push({
+          pathname: '/homeScreen',
+          query: {
+            skills:skills
+          }
+        })
       } else {
-        return recruits
+        router.push('/homeScreen')
       }
-    });
-    setFilteredRecruits([...alterRecruitList]);
-    alterRecruitList = [];
   };
 
   return (
     <div className="bg-white pt-5 px-10">
-      <form onSubmit={handleSubmit(onSubmit)} className="w-full sm:w-3/4">
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full sm:w-3/4 md:w-3/5">
         <div>
           <p className=" sm:text-2xl text-gray-600 mb-1">条件検索</p>
           <PlainInput

--- a/src/features/recruit/components/templates/EditRecruit.tsx
+++ b/src/features/recruit/components/templates/EditRecruit.tsx
@@ -64,10 +64,11 @@ export const EditRecruit = () => {
   }
 
   return(
-    <div className=" min-h-screen w-96 space-y-6 my-12">
+    <div className="flex flex-col items-center min-h-screen w-full space-y-6 my-12">
       <h2 className="text-center font-bold ">募集情報編集</h2>
       <form
        onSubmit={handleSubmit(onEditSubmit)}
+       className="flex flex-col w-96 sm:w-sm"
       >
         <PlainInput
           labelText="ハッカソン名"

--- a/src/features/recruit/components/templates/LikedRecruitList.tsx
+++ b/src/features/recruit/components/templates/LikedRecruitList.tsx
@@ -21,6 +21,7 @@ export const LikedRecruitList = (): JSX.Element => {
                   headline={recruit.headline}
                   programingSkills={recruit.programingSkills}
                   hackthonName={recruit.hackthonName}
+                  recruiter={recruit.recruiter}
                 />
               );
           })}

--- a/src/features/recruit/components/templates/MyRecruitsAndRelatedRecruits.tsx
+++ b/src/features/recruit/components/templates/MyRecruitsAndRelatedRecruits.tsx
@@ -11,7 +11,7 @@ import { useMyRecruits } from "../../hooks/useMyRecruits"
 
 export const MyRecruitsAndRelatedRecruits = () => {
   return (
-    <div className="flex flex-col items-center justify-start h-screen space-y-10">
+    <div className="flex flex-col items-center h-screen w-full space-y-10">
       {/* 自分で作成した募集 */}
       <MyRecruitsList />
 

--- a/src/features/recruit/components/templates/OwnRecruitDetail.tsx
+++ b/src/features/recruit/components/templates/OwnRecruitDetail.tsx
@@ -12,14 +12,13 @@ import { useRecruit } from "../../hooks/useRecruit";
 
 export const OwnRecruitDetail: React.FC = ()  => {
   const router = useRouter();
+  const { recruit } = useRecruit();
   
   //モーダル関係
   const [isOpen, setIsOpen] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
   const [color, setColor] = useState<boolean>();
   const closeModal = () => setIsOpen(false);
-
-  const { recruit } = useRecruit();
 
   if (recruit === undefined) return <Loading />
 
@@ -75,9 +74,9 @@ export const OwnRecruitDetail: React.FC = ()  => {
   }
 
   return (
-    <div className="h-full flex justify-center items-center sm:bg-gray-100">
-      <div className="flex flex-col items-center w-4/5 sm:w-base md:w-sm  bg-white rounded-sm">
-        <div className="h-20 sm:h-40 w-full flex flex-col justify-center items-center bg-gradient-to-r from-green-300 to-pink-300 text-white rounded-sm rounded-b-none relative">
+    <div className="h-full w-full flex justify-center items-center bg-white">
+      <div className="flex flex-col items-center w-4/5 sm:w-sm md:w-md lg:w-lg bg-white rounded-md">
+        <div className="h-20 sm:h-40 w-full flex flex-col justify-center items-center bg-gradient-to-r from-green-300 to-pink-300 text-white rounded-md relative">
           {/* 削除ボタン
           <button onClick={deleteRecruit} className="absolute top-4 right-4 text-red-500">
             <AiFillDelete size={30} />
@@ -86,7 +85,7 @@ export const OwnRecruitDetail: React.FC = ()  => {
           <h1 className="text-3xl sm:text-4xl font-bold text-center">{recruit.hackthonName}</h1>
         </div>
 
-        <div className="w-full sm:w-4/5 flex flex-col">
+        <div className="w-full flex flex-col">
           <div className="flex items-center justify-center h-20 sm:h-24 border-b border-gray-200 text-lg">
             {recruit.headline}
           </div>
@@ -160,26 +159,26 @@ export const OwnRecruitDetail: React.FC = ()  => {
         <div className="flex items-center justify-center w-full my-10">
           {
             recruit?.product.length !== 0 ? (
-              <div className="w-4/5 flex flex-row items-center justify-between">
+              <div className="w-full flex flex-row items-center justify-between">
                 <div className="flex flex-row w-1/2">
-                  <Link href={`/recruit/editRecruit?id=${recruit.id}`} className="bg-green-400 hover:bg-green-500 px-4 py-4 rounded-md text-white font-semibold">募集情報を編集する</Link>
+                  <Link href={`/recruit/editRecruit?id=${recruit.id}`} className="bg-green-400 hover:bg-green-500 px-4 py-4 rounded-md text-white">募集情報を編集する</Link>
                   {/* 削除ボタン */}
                   <button onClick={deleteRecruit} className="ml-5 text-gray-400">
                     <AiFillDelete size={25} />
                   </button>
                 </div>
-                <Link href={`/product/${recruit.product[0]?.id}`} className="bg-green-400 hover:bg-green-500 px-6 py-4 rounded-md text-white font-semibold">Productページへ</Link>
+                <Link href={`/product/${recruit.product[0]?.id}`} className="bg-green-400 hover:bg-green-500 px-6 py-4 rounded-md text-white">Productページへ</Link>
               </div>
             ) : (
-              <div className="w-4/5 flex flex-row items-center justify-between">
+              <div className="w-full flex flex-row items-center justify-between">
                 <div className="flex flex-row w-1/2">
-                  <Link href={`/recruit/editRecruit?id=${recruit.id}`} className="bg-green-400 hover:bg-green-500 px-2 py-2 rounded-md text-white font-semibold">募集情報を編集する</Link>
+                  <Link href={`/recruit/editRecruit?id=${recruit.id}`} className="bg-green-400 hover:bg-green-500 p-2 rounded-md text-white  text-xs sm:text-base">募集情報を編集する</Link>
                   {/* 削除ボタン */}
                   <button onClick={deleteRecruit} className="ml-5 text-gray-400">
-                    <AiFillDelete size={25} />
+                    <AiFillDelete size={20} />
                   </button>
                 </div>
-                <Link href={`/product/uploadProduct?recruitId=${recruit?.id}`} className="bg-green-400 hover:bg-green-500 px-2 py-2 rounded-md text-white font-semibold">UPLOADする</Link>
+                <Link href={`/product/uploadProduct?recruitId=${recruit?.id}`} className="bg-green-400 hover:bg-green-500 p-2 rounded-md text-white ">UPLOADする</Link>
               </div>
             )
           }

--- a/src/features/recruit/components/templates/RecruitDetail.tsx
+++ b/src/features/recruit/components/templates/RecruitDetail.tsx
@@ -10,6 +10,7 @@ import { useRecoilValue } from "recoil";
 import { Loading } from "../../../../components/organisms/Loading/Loading";
 import { RecruitLikeButton } from "@/features/recruit/components/molecules/Button/RecruitLikeButton";
 import { useRecruit } from "../../hooks/useRecruit";
+import { PersonIcon } from "@/components/molecules/Icon/PersonIcon";
 
 
 export const RecruitDetail: React.FC = () => {
@@ -58,14 +59,14 @@ export const RecruitDetail: React.FC = () => {
   if (isLiked === undefined || isParticipant === undefined) return <Loading/>
 
   return (
-    <div className="h-full min-h-screen flex justify-center items-center sm:bg-gray-100  text-gray-600">
-      <div className="flex flex-col items-center w-4/5 sm:w-base md:w-sm  bg-white rounded-sm">
-        <div className="h-20 sm:h-40 w-full flex flex-col justify-center items-center bg-gradient-to-r from-green-300 to-pink-300 text-white rounded-sm rounded-b-none">
+    <div className="h-full min-h-screen w-full flex justify-center items-center sm:bg-white  text-gray-600">
+      <div className="flex flex-col items-center w-4/5 sm:w-sm md:w-md  lg:w-lg bg-white rounded-md">
+        <div className="h-20 sm:h-40 w-full flex flex-col justify-center items-center bg-gradient-to-r from-green-300 to-pink-300 text-white rounded-md ">
           {/* ハッカソン名 */}
           <h1 className="text-3xl sm:text-4xl font-bold text-center">{recruit?.hackthonName}</h1>
         </div>
 
-        <div className="w-full sm:w-4/5 flex flex-col">
+        <div className="w-full  flex flex-col">
           <div className="flex items-center justify-center h-20 sm:h-24 border-b border-gray-200 text-lg">
             {recruit?.headline}
           </div>

--- a/src/features/recruit/stores/filteredRecruits.ts
+++ b/src/features/recruit/stores/filteredRecruits.ts
@@ -1,8 +1,0 @@
-import { Recruit } from "@/features/recruit/types/recruit";
-import { atom } from "recoil";
-import { recruitAtomState } from "./recruitAtom";
-
-export const filteredRecruitAtomState = atom<Recruit[]>({
-  key: "filteredRecruitAtomState",
-  default: [],
-});

--- a/src/features/recruit/types/recruitCard.ts
+++ b/src/features/recruit/types/recruitCard.ts
@@ -4,11 +4,6 @@ export type recruitCard = {
   recruitment_details: string;
   programing_skills?: Option[];
   user_id: string;
-  //   tag_id?: any;
-  //   number_of_applicants?: string[];
-  //   development_period?: string;
-  //   hackathon_url?: string;
-  //   recruitment_number?: number;
 };
 
 //react-hook-form用のprogramingの型

--- a/src/pages/homeScreen.tsx
+++ b/src/pages/homeScreen.tsx
@@ -1,12 +1,10 @@
 import { UserLayout } from "@/components/layouts/Layout/UserLayout";
 import { HomeScreen } from "@/features/recruit/components/templates/HomeScreen";
-import { filteredRecruitAtomState } from "@/features/recruit/stores/filteredRecruits";
 import { recruitAtomState } from "@/features/recruit/stores/recruitAtom";
 import { recruitRepository } from "@/features/recruit/modules/recruit/recruit.repository";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { ReactElement, useEffect } from "react";
 import { useSetRecoilState } from "recoil";
-import { NextPageWithLayout } from "./_app";
 
 export const getStaticProps: GetStaticProps = async () => {
   const recruitsArray = await recruitRepository.getRecruits();
@@ -25,12 +23,10 @@ type Props = {
 
 const HomeScreenPage = ({ recruitsArray }: Props) => {
   const setRecruits = useSetRecoilState(recruitAtomState);
-  const setFilteredRecruits = useSetRecoilState(filteredRecruitAtomState);
 
   //しなくても良い？
   useEffect(() => {
     setRecruits(recruitsArray);
-    setFilteredRecruits(recruitsArray);
   }, [recruitsArray]);
 
   return <HomeScreen />;
@@ -40,7 +36,3 @@ HomeScreenPage.getLayout = (page: ReactElement) => (
   <UserLayout> {page} </UserLayout>
 );
 export default HomeScreenPage;
-
-//パスを変える
-//queryパラメータで変える
-// 動的ルーティング

--- a/src/pages/product/uploadProduct.tsx
+++ b/src/pages/product/uploadProduct.tsx
@@ -3,13 +3,7 @@ import { UploadProduct } from "@/features/product/components/templates/UploadPro
 import { ReactElement } from "react";
 
 
-const UploadProductPage = () => {
-   return (
-      <>
-         <UploadProduct />
-      </>
-   )
-}
+const UploadProductPage = () => <UploadProduct />
 
 UploadProductPage.getLayout = (page: ReactElement) => {
   return ( <UserLayout>{ page }</UserLayout> )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,9 +24,9 @@ module.exports = {
       width: {
         "100": "100px",
         'base': '500px',
-        'sm': '640px',
-        'md': '768px',
-        'lg': '1024px',
+        'sm': '440px',
+        'md': '560px',
+        'lg': '770px',
         'xl': '1280px',
       }
     },


### PR DESCRIPTION
--概要
1.sideBarに伴う画面崩れの対応
2.recruitの条件探索をrecoilを利用した方法からqueryを利用した方法に変更
3.recruitCardのデザイン変更
<img width="1728" alt="スクリーンショット 2023-08-07 12 37 14" src="https://github.com/nagayamajun/unite-replace-front/assets/85071324/3d0bf717-32c5-4e1b-8f4e-4072cadd5a43">
<img width="1728" alt="スクリーンショット 2023-08-07 12 39 06" src="https://github.com/nagayamajun/unite-replace-front/assets/85071324/fd060224-52a5-45af-9774-93b37deb4311">
